### PR TITLE
Fix default arch resolve function

### DIFF
--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -23,10 +23,10 @@ func FillDefault(y *LimaYAML) {
 
 func resolveArch(s string) Arch {
 	if s == "" || s == "default" {
-		if runtime.GOOS == "amd64" {
-			return AARCH64
-		} else {
+		if runtime.GOARCH == "amd64" {
 			return X8664
+		} else {
+			return AARCH64
 		}
 	}
 	return s


### PR DESCRIPTION
As described in [template yaml](https://github.com/AkihiroSuda/lima/blob/605e06273d6b423b5ba97a22a781e64b52fabf90/pkg/limayaml/default.TEMPLATE.yaml#L3), default in `arch` field means host architecture, but `resolveArch` function returns opposite value.