### PR TITLE
Make it working on Apple Silicon

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -103,7 +103,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 		args = append(args, "-machine", "q35,accel="+accel)
 	case limayaml.AARCH64:
 		args = append(args, "-cpu", "cortex-a72")
-		args = append(args, "-machine", "virt,accel="+accel)
+		args = append(args, "-machine", "virt,accel="+accel+",highmem=off")
 	}
 
 	// SMP


### PR DESCRIPTION
Without `highmem=off` in `-machine` flag QEMU exits with error "qemu-system-aarch64: VCPU supports less PA bits (36) than requested by the memory map (40)".