### PR TITLE
Implement system and user provisioning scripts

### DIFF
--- a/examples/k3s.yaml
+++ b/examples/k3s.yaml
@@ -1,0 +1,42 @@
+# Deploy kubernetes via k3s (which installs a bundled containerd).
+#
+# It can be accessed from the host by exporting the kubeconfig file;
+# the ports are already forwarded automatically by lima:
+#
+# $ export KUBECONFIG=$PWD/kubeconfig.yaml
+# $ limactl shell k3s sudo cat /etc/rancher/k3s/k3s.yaml >$KUBECONFIG
+# $ kubectl get no
+# NAME       STATUS   ROLES                  AGE   VERSION
+# lima-k3s   Ready    control-plane,master   69s   v1.21.1+k3s1
+
+images:
+- location: "~/Downloads/hirsute-server-cloudimg-amd64.img"
+  arch: "x86_64"
+
+mounts: []
+
+ssh:
+  localPort: 60022
+
+containerd:
+  system: false
+  user: false
+
+provision:
+- mode: system
+  script: |
+    #!/bin/sh
+    curl -sfL https://get.k3s.io | sh -
+
+probes:
+- script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    if ! timeout 30s bash -c "until test -f /etc/rancher/k3s/k3s.yaml; do sleep 3; done"; then
+            echo >&2 "k3s is not running yet"
+            exit 1
+    fi
+  hint: |
+    The k3s kubeconfig file has not yet been created.
+    Run "lima bash sudo journalctl -u k3s" to check the log.
+    If that is still empty, check the bottom of the log at "/var/log/cloud-init-output.log".

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -29,9 +29,10 @@ func GenerateISO9660(isoPath, name string, y *limayaml.LimaYAML) error {
 		return err
 	}
 	args := TemplateArgs{
-		Name: name,
-		User: u.Username,
-		UID:  uid,
+		Name:      name,
+		User:      u.Username,
+		UID:       uid,
+		Provision: y.Provision,
 	}
 	for _, f := range sshutil.DefaultPubKeys() {
 		args.SSHPubKeys = append(args.SSHPubKeys, f.Content)

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -29,10 +29,11 @@ func GenerateISO9660(isoPath, name string, y *limayaml.LimaYAML) error {
 		return err
 	}
 	args := TemplateArgs{
-		Name:      name,
-		User:      u.Username,
-		UID:       uid,
-		Provision: y.Provision,
+		Name:       name,
+		User:       u.Username,
+		UID:        uid,
+		Provision:  y.Provision,
+		Containerd: Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
 	}
 	for _, f := range sshutil.DefaultPubKeys() {
 		args.SSHPubKeys = append(args.SSHPubKeys, f.Content)

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -4,6 +4,8 @@ import (
 	_ "embed"
 	"path/filepath"
 
+	"github.com/AkihiroSuda/lima/pkg/limayaml"
+
 	"github.com/AkihiroSuda/lima/pkg/templateutil"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/pkg/errors"
@@ -22,6 +24,7 @@ type TemplateArgs struct {
 	UID        int
 	SSHPubKeys []string
 	Mounts     []string // abs path, accessible by the User
+	Provision  []limayaml.Provision
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {

--- a/pkg/cidata/template.go
+++ b/pkg/cidata/template.go
@@ -18,6 +18,10 @@ var (
 	metaDataTemplate string
 )
 
+type Containerd struct {
+	System bool
+	User   bool
+}
 type TemplateArgs struct {
 	Name       string // instance name
 	User       string // user name
@@ -25,6 +29,7 @@ type TemplateArgs struct {
 	SSHPubKeys []string
 	Mounts     []string // abs path, accessible by the User
 	Provision  []limayaml.Provision
+	Containerd Containerd
 }
 
 func ValidateTemplateArgs(args TemplateArgs) error {

--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -13,9 +13,9 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: true
     ssh-authorized-keys:
-{{range $val := .SSHPubKeys}}
+    {{- range $val := .SSHPubKeys}}
       - {{$val}}
-{{end}}
+    {{- end}}
 
 write_files:
  - content: |
@@ -49,10 +49,10 @@ write_files:
       loginctl enable-linger "{{.User}}"
 
       # Create mount points
-      {{range $val := .Mounts}}
+      {{- range $val := .Mounts}}
       mkdir -p "{{$val}}"
       chown "{{$.User}}" "{{$val}}" || true
-      {{end}}
+      {{- end}}
 
       # Install or update the guestagent binary
       mkdir -p -m 600 /mnt/lima-cidata
@@ -110,3 +110,26 @@ write_files:
    owner: root:root
    path: /var/lib/cloud/scripts/per-boot/20-install-containerd.boot.sh
    permissions: '0755'
+{{- if .Provision}}
+ - content: |
+      #!/bin/bash
+      set -eu -o pipefail
+      {{- range $i, $val := .Provision}}
+      {{- $script := printf "/var/lib/lima-guestagent/provision-%02d-%s" $i $val.Mode}}
+      {{- if eq $val.Mode "system"}}
+      {{$script}}
+      {{- else}}
+      until [ -e "/run/user/{{.UID}}/systemd/private" ]; do sleep 3; done
+      sudo -iu "{{.User}}" "XDG_RUNTIME_DIR=/run/user/{{.UID}}" {{$script}}
+      {{- end}}
+      {{- end}}
+   owner: root:root
+   path: /var/lib/cloud/scripts/per-boot/30-execute-provision-scripts.boot.sh
+   permissions: '0755'
+{{- end}}
+{{- range $i, $val := .Provision}}
+ - content: {{printf "%q" $val.Script}}
+   owner: root:root
+   path: {{printf "/var/lib/lima-guestagent/provision-%02d-%s" $i $val.Mode}}
+   permissions: '0755'
+{{- end}}

--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -22,6 +22,7 @@ write_files:
       #!/bin/bash
       set -eux -o pipefail
 
+      {{- if .Containerd.User}}
       # Enable rootless containers
       if [ ! -e "/etc/systemd/system/user@.service.d/lima.conf" ]; then
         mkdir -p "/etc/systemd/system/user@.service.d"
@@ -47,6 +48,7 @@ write_files:
         grep -qw "{{.User}}" $f || echo "{{.User}}:100000:65536" >> $f
       done
       loginctl enable-linger "{{.User}}"
+      {{- end}}
 
       # Create mount points
       {{- range $val := .Mounts}}
@@ -67,6 +69,7 @@ write_files:
    # We do not use per-once.
    path: /var/lib/cloud/scripts/per-boot/00-base.boot.sh
    permissions: '0755'
+ {{- if or .Mounts .Containerd.User}}
  - content: |
       #!/bin/bash
       set -eux -o pipefail
@@ -74,16 +77,42 @@ write_files:
       if command -v apt-get 2>&1 >/dev/null; then
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
-        apt-get install -y sshfs uidmap
+        {{- if .Mounts}}
+        apt-get install -y sshfs
+        {{- end }}
+        {{- if .Containerd.User}}
+        apt-get install -y uidmap
+        {{- end }}
       elif command -v dnf 2>&1 >/dev/null; then
-        dnf install -y fuse-sshfs shadow-utils
+        : {{/* make sure the "elif" block is never empty */}}
+        {{- if .Mounts}}
+        dnf install -y fuse-sshfs
+        {{- end}}
+        {{- if .Containerd.User}}
+        dnf install -y shadow-utils
+        {{- end}}
       fi
    owner: root:root
    path: /var/lib/cloud/scripts/per-boot/10-install-packages.boot.sh
    permissions: '0755'
+{{- end}}
+{{- if or .Containerd.System .Containerd.User}}
  - content: |
       #!/bin/bash
       set -eux -o pipefail
+      if [ ! -x /usr/local/bin/nerdctl ]; then
+        version="0.8.3"
+        goarch="amd64"
+        if [ "$(uname -m )" = "aarch64 "]; then
+          goarch="arm64"
+        fi
+        curl -fsSL https://github.com/containerd/nerdctl/releases/download/v${version}/nerdctl-full-${version}-linux-${goarch}.tar.gz | tar Cxz /usr/local
+      fi
+      {{- if .Containerd.System}}
+      systemctl enable containerd
+      systemctl start containerd
+      {{- end}}
+      {{- if .Containerd.User}}
       modprobe tap || true
       if [ ! -e "/home/{{.User}}.linux/.config/containerd/config.toml" ]; then
         mkdir -p "/home/{{.User}}.linux/.config/containerd"
@@ -95,21 +124,17 @@ write_files:
       EOF
         chown -R "{{.User}}" "/home/{{.User}}.linux/.config"
       fi
-      if [ ! -x /usr/local/bin/nerdctl ]; then
-        version="0.8.3"
-        goarch="amd64"
-        if [ "$(uname -m )" = "aarch64 "]; then
-          goarch="arm64"
-        fi
-        curl -fsSL https://github.com/containerd/nerdctl/releases/download/v${version}/nerdctl-full-${version}-linux-${goarch}.tar.gz | tar Cxz /usr/local
+      if [ ! -e "/home/{{.User}}}}.linux/.config/systemd/user/containerd.service" ]; then
         until [ -e "/run/user/{{.UID}}/systemd/private" ]; do sleep 3; done
         sudo -iu "{{.User}}" "XDG_RUNTIME_DIR=/run/user/{{.UID}}" containerd-rootless-setuptool.sh install
         sudo -iu "{{.User}}" "XDG_RUNTIME_DIR=/run/user/{{.UID}}" containerd-rootless-setuptool.sh install-buildkit
         sudo -iu "{{.User}}" "XDG_RUNTIME_DIR=/run/user/{{.UID}}" containerd-rootless-setuptool.sh install-stargz
       fi
+      {{- end}}
    owner: root:root
    path: /var/lib/cloud/scripts/per-boot/20-install-containerd.boot.sh
    permissions: '0755'
+{{- end}}
 {{- if .Provision}}
  - content: |
       #!/bin/bash

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -54,7 +54,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		return nil
 	})
 	var mErr error
-	if err := a.waitForRequirements(ctx, "essential", essentialRequirements); err != nil {
+	if err := a.waitForRequirements(ctx, "essential", a.essentialRequirements()); err != nil {
 		mErr = multierror.Append(mErr, err)
 	}
 	mounts, err := a.setupMounts(ctx)
@@ -71,7 +71,7 @@ func (a *HostAgent) Run(ctx context.Context) error {
 		return unmountMErr
 	})
 	go a.watchGuestAgentEvents(ctx)
-	if err := a.waitForRequirements(ctx, "optional", optionalRequirements); err != nil {
+	if err := a.waitForRequirements(ctx, "optional", a.optionalRequirements()); err != nil {
 		mErr = multierror.Append(mErr, err)
 	}
 	return mErr

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -2,6 +2,7 @@ package hostagent
 
 import (
 	"context"
+	"github.com/AkihiroSuda/lima/pkg/limayaml"
 	"time"
 
 	"github.com/AkihiroSuda/sshocker/pkg/ssh"
@@ -119,6 +120,15 @@ Make sure that you are using an officially supported image.
 Also see "/var/log/cloud-init-output.log" in the guest.
 `,
 		})
+	}
+	for _, probe := range a.y.Probes {
+		if probe.Mode == limayaml.ProbeModeReadiness {
+			req = append(req, requirement{
+				description: probe.Description,
+				script:      probe.Script,
+				debugHint:   probe.Hint,
+			})
+		}
 	}
 	return req
 }

--- a/pkg/limayaml/default.TEMPLATE.yaml
+++ b/pkg/limayaml/default.TEMPLATE.yaml
@@ -85,3 +85,17 @@ containerd:
 #       set number
 #       EOF
 
+# probes:
+#  # Only `readiness` probes are supported right now.
+#  - mode: readiness
+#    description: vim to be installed
+#    script: |
+#       #!/bin/bash
+#       set -eux -o pipefail
+#       if ! timeout 30s bash -c "until command -v vim; do sleep 3; done"; then
+#         echo >&2 "vim is not installed yet"
+#         exit 1
+#       fi
+#    hint: |
+#      vim was not installed in the guest. Make sure the package system is working correctly.
+#      Also see "/var/log/cloud-init-output.log" in the guest.

--- a/pkg/limayaml/default.TEMPLATE.yaml
+++ b/pkg/limayaml/default.TEMPLATE.yaml
@@ -58,6 +58,16 @@ video:
   # Default: "none"
   display: "none"
 
+containerd:
+  # Enable system-wide containerd (systemctl enable containerd)
+  # Default: false
+  system: false
+  # Enable user-scoped containerd (systemctl --user enable containerd)
+  # Default: true
+  user: true
+
+# Provisioning scripts need to be idempotent because they might be called
+# multiple times, e.g. when the host VM is being restarted.
 # provision:
 #   # `system` is executed with the root privilege
 #   - mode: system
@@ -74,3 +84,4 @@ video:
 #       cat <<EOF > ~/.vimrc
 #       set number
 #       EOF
+

--- a/pkg/limayaml/default.TEMPLATE.yaml
+++ b/pkg/limayaml/default.TEMPLATE.yaml
@@ -58,17 +58,19 @@ video:
   # Default: "none"
   display: "none"
 
-#UNIMPLEMENTED| provision:
-#UNIMPLEMENTED|   # `system` is executed with the root privilege
-#UNIMPLEMENTED|   system: |
-#UNIMPLEMENTED|     #!/bin/bash
-#UNIMPLEMENTED|     set -eux -o pipefail
-#UNIMPLEMENTED|     export DEBIAN_FRONTEND=noninteractive
-#UNIMPLEMENTED|     apt-get install -y vim
-#UNIMPLEMENTED|   # `user` is executed without the root privilege
-#UNIMPLEMENTED|   user: |
-#UNIMPLEMENTED|     #!/bin/bash
-#UNIMPLEMENTED|     set -eux -o pipefail
-#UNIMPLEMENTED|     cat <<EOF > ~/.vimrc
-#UNIMPLEMENTED|     set number
-#UNIMPLEMENTED|     EOF
+# provision:
+#   # `system` is executed with the root privilege
+#   - mode: system
+#     script: |
+#       #!/bin/bash
+#       set -eux -o pipefail
+#       export DEBIAN_FRONTEND=noninteractive
+#       apt-get install -y vim
+#   # `user` is executed without the root privilege
+#   - mode: user
+#     script: |
+#       #!/bin/bash
+#       set -eux -o pipefail
+#       cat <<EOF > ~/.vimrc
+#       set number
+#       EOF

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -19,9 +19,14 @@ func FillDefault(y *LimaYAML) {
 	if y.Disk == "" {
 		y.Disk = "100GiB"
 	}
-
 	if y.Video.Display == "" {
 		y.Video.Display = "none"
+	}
+	for i := range y.Provision {
+		provision := &y.Provision[i]
+		if provision.Mode == "" {
+			provision.Mode = ProvisionModeSystem
+		}
 	}
 }
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -1,6 +1,9 @@
 package limayaml
 
-import "runtime"
+import (
+	"fmt"
+	"runtime"
+)
 
 func FillDefault(y *LimaYAML) {
 	y.Arch = resolveArch(y.Arch)
@@ -33,6 +36,15 @@ func FillDefault(y *LimaYAML) {
 	}
 	if y.Containerd.User == nil {
 		y.Containerd.User = &[]bool{true}[0]
+	}
+	for i := range y.Probes {
+		probe := &y.Probes[i]
+		if probe.Mode == "" {
+			probe.Mode = ProbeModeReadiness
+		}
+		if probe.Description == "" {
+			probe.Description = fmt.Sprintf("user probe %d/%d", i+1, len(y.Probes))
+		}
 	}
 }
 

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -28,6 +28,12 @@ func FillDefault(y *LimaYAML) {
 			provision.Mode = ProvisionModeSystem
 		}
 	}
+	if y.Containerd.System == nil {
+		y.Containerd.System = &[]bool{false}[0]
+	}
+	if y.Containerd.User == nil {
+		y.Containerd.User = &[]bool{true}[0]
+	}
 }
 
 func resolveArch(s string) Arch {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -12,6 +12,7 @@ type LimaYAML struct {
 	Video      Video       `yaml:"video,omitempty"`
 	Provision  []Provision `yaml:"provision,omitempty"`
 	Containerd Containerd  `yaml:"containerd,omitempty"`
+	Probes     []Probe     `yaml:"probes,omitempty"`
 }
 
 type Arch = string
@@ -61,4 +62,17 @@ type Provision struct {
 type Containerd struct {
 	System *bool `yaml:"system,omitempty"`
 	User   *bool `yaml:"user,omitempty"`
+}
+
+type ProbeMode = string
+
+const (
+	ProbeModeReadiness ProbeMode = "readiness"
+)
+
+type Probe struct {
+	Mode        ProbeMode // default: "readiness"
+	Description string
+	Script      string
+	Hint        string
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -1,15 +1,16 @@
 package limayaml
 
 type LimaYAML struct {
-	Arch     Arch     `yaml:"arch,omitempty"`
-	Images   []Image  `yaml:"images"` // REQUIRED
-	CPUs     int      `yaml:"cpus,omitempty"`
-	Memory   string   `yaml:"memory,omitempty"` // go-units.RAMInBytes
-	Disk     string   `yaml:"disk,omitempty"`   // go-units.RAMInBytes
-	Mounts   []Mount  `yaml:"mounts,omitempty"`
-	SSH      SSH      `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware Firmware `yaml:"firmware,omitempty"`
-	Video    Video    `yaml:"video,omitempty"`
+	Arch      Arch        `yaml:"arch,omitempty"`
+	Images    []Image     `yaml:"images"` // REQUIRED
+	CPUs      int         `yaml:"cpus,omitempty"`
+	Memory    string      `yaml:"memory,omitempty"` // go-units.RAMInBytes
+	Disk      string      `yaml:"disk,omitempty"`   // go-units.RAMInBytes
+	Mounts    []Mount     `yaml:"mounts,omitempty"`
+	SSH       SSH         `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware  Firmware    `yaml:"firmware,omitempty"`
+	Video     Video       `yaml:"video,omitempty"`
+	Provision []Provision `yaml:"provision,omitempty"`
 }
 
 type Arch = string
@@ -42,4 +43,16 @@ type Firmware struct {
 type Video struct {
 	// Display is a QEMU display string
 	Display string `yaml:"display,omitempty"`
+}
+
+type ProvisionMode = string
+
+const (
+	ProvisionModeSystem ProvisionMode = "system"
+	ProvisionModeUser   ProvisionMode = "user"
+)
+
+type Provision struct {
+	Mode   ProvisionMode `yaml:"mode"` // default: "system"
+	Script string        `yaml:"script"`
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -1,16 +1,17 @@
 package limayaml
 
 type LimaYAML struct {
-	Arch      Arch        `yaml:"arch,omitempty"`
-	Images    []Image     `yaml:"images"` // REQUIRED
-	CPUs      int         `yaml:"cpus,omitempty"`
-	Memory    string      `yaml:"memory,omitempty"` // go-units.RAMInBytes
-	Disk      string      `yaml:"disk,omitempty"`   // go-units.RAMInBytes
-	Mounts    []Mount     `yaml:"mounts,omitempty"`
-	SSH       SSH         `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware  Firmware    `yaml:"firmware,omitempty"`
-	Video     Video       `yaml:"video,omitempty"`
-	Provision []Provision `yaml:"provision,omitempty"`
+	Arch       Arch        `yaml:"arch,omitempty"`
+	Images     []Image     `yaml:"images"` // REQUIRED
+	CPUs       int         `yaml:"cpus,omitempty"`
+	Memory     string      `yaml:"memory,omitempty"` // go-units.RAMInBytes
+	Disk       string      `yaml:"disk,omitempty"`   // go-units.RAMInBytes
+	Mounts     []Mount     `yaml:"mounts,omitempty"`
+	SSH        SSH         `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware   Firmware    `yaml:"firmware,omitempty"`
+	Video      Video       `yaml:"video,omitempty"`
+	Provision  []Provision `yaml:"provision,omitempty"`
+	Containerd Containerd  `yaml:"containerd,omitempty"`
 }
 
 type Arch = string
@@ -55,4 +56,9 @@ const (
 type Provision struct {
 	Mode   ProvisionMode `yaml:"mode"` // default: "system"
 	Script string        `yaml:"script"`
+}
+
+type Containerd struct {
+	System *bool `yaml:"system,omitempty"`
+	User   *bool `yaml:"user,omitempty"`
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -111,6 +111,13 @@ func ValidateRaw(y LimaYAML) error {
 					i, ProvisionModeSystem, ProvisionModeUser)
 		}
 	}
-
+	for i, p := range y.Probes {
+		switch p.Mode {
+		case ProbeModeReadiness:
+		default:
+			return errors.Errorf("field `probe[%d].mode` can only be %q",
+				i, ProbeModeReadiness)
+		}
+	}
 	return nil
 }

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -103,5 +103,14 @@ func ValidateRaw(y LimaYAML) error {
 
 	// y.Firmware.LegacyBIOS is ignored for aarch64, but not a fatal error.
 
+	for i, p := range y.Provision {
+		switch p.Mode {
+		case ProvisionModeSystem, ProvisionModeUser:
+		default:
+			return errors.Errorf("field `provision[%d].mode` must be either %q or %q",
+					i, ProvisionModeSystem, ProvisionModeUser)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Fixes #33 

In addition this PR implements a `bare-vm` setting that disables installation of optional requirements (`containerd` and `nerdctl`), and also skips installation of `sshfs` if there are no directories to mount.

Example use to provision kubernetes via `k3s` (although not in rootless mode):

```console
$ cat k3s.yaml
images:
- location: "~/Downloads/hirsute-server-cloudimg-amd64.img"
  arch: "x86_64"

mounts: []

ssh:
  localPort: 60022

bare-vm: true

provision:
  system: |
    #!/bin/sh
    curl -sfL https://get.k3s.io | sh -
$ limactl start --tty=false k3s.yaml
[...]
INFO[0032] READY. Run `lima bash` to open the shell.
INFO[0032] Forwarding "/run/user/501/lima-guestagent.sock" (guest) to "/Users/jan/.lima/k3s/ga.sock" (host)
INFO[0051] Forwarding TCP port 6444
INFO[0051] Forwarding TCP port 6443
INFO[0054] Forwarding TCP port 10010
[...]
```

And in a second shell:

```console
$ export KUBECONFIG=$PWD/kubeconfig.yaml
$ limactl shell k3s sudo cat /etc/rancher/k3s/k3s.yaml >$KUBECONFIG
$ kubectl get no
NAME       STATUS   ROLES                  AGE   VERSION
lima-k3s   Ready    control-plane,master   69s   v1.21.1+k3s1
$ kubectl get po -A
NAMESPACE     NAME                                      READY   STATUS      RESTARTS   AGE
kube-system   coredns-7448499f4d-gsv6h                  1/1     Running     0          67s
kube-system   local-path-provisioner-5ff76fc89d-kbmtj   1/1     Running     0          67s
kube-system   metrics-server-86cbb8457f-g7bjg           1/1     Running     0          67s
kube-system   helm-install-traefik-crd-sr9m8            0/1     Completed   0          67s
kube-system   helm-install-traefik-f587z                0/1     Completed   1          67s
kube-system   svclb-traefik-sqj88                       2/2     Running     0          47s
kube-system   traefik-97b44b794-j8t8s                   1/1     Running     0          47s
```