### PR TITLE
Fix containerd.system=true provisioning

### DIFF
--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -113,6 +113,7 @@ write_files:
         umount /mnt/lima-cidata
       fi
       {{- if .Containerd.System}}
+      mkdir -p /etc/containerd
       cat >"/etc/containerd/config.toml" <<EOF
         version = 2
         [proxy_plugins]


### PR DESCRIPTION
Make sure `/etc/containerd` exists before writing `/etc/containerd/config.toml`.
