### PR TITLE
Add support for Alpine guest OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        example: [examples/default.yaml, examples/debian.yaml, examples/fedora.yaml]
+        example: [default.yaml, alpine.yaml, debian.yaml, fedora.yaml]
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -81,11 +81,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/Library/Caches/lima/download
-          key: ${{ runner.os }}-${{ matrix.example }}
+          key: ${{ runner.os }}-examples/${{ matrix.example }}
       - name: Test
         env:
           EXAMPLE: ${{ matrix.example }}
-        run: ./hack/test-example.sh $EXAMPLE
+        run: ./hack/test-example.sh examples/$EXAMPLE
 
   artifacts:
     name: Artifacts

--- a/examples/alpine.yaml
+++ b/examples/alpine.yaml
@@ -1,0 +1,21 @@
+images:
+- location: https://github.com/rancher-sandbox/alpine-lima/releases/download/v0.0.1/alpine-lima-ci-3.13.5-x86_64.iso
+  arch: "x86_64"
+
+mounts:
+- location: "~"
+  writable: false
+- location: "/tmp/lima"
+  writable: true
+
+ssh:
+  # localPort is changed from 60022 to avoid conflicting with the default.
+  # (TODO: assign localPort automatically)
+  localPort: 60020
+
+firmware:
+  legacyBIOS: true
+
+containerd:
+  system: false
+  user: false

--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -32,6 +32,11 @@ limactl validate "$FILE"
 declare -A CHECKS=(["systemd"]="1" ["systemd-strict"]="1" ["mount-home"]="1" ["containerd-user"]="1")
 
 case "$NAME" in
+"alpine")
+	WARNING "Alpine does not support systemd"
+	CHECKS["systemd"]=
+	CHECKS["containerd-user"]=
+	;;
 "k3s")
 	ERROR "File \"$FILE\" is not testable with this script"
 	exit 1

--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -19,6 +19,75 @@ users:
 
 write_files:
  - content: |
+      #!/bin/sh
+      # This script pretends that /bin/ash can be used as /bin/bash, so all following
+      # cloud-init scripts can use `#!/bin/bash` and `set -o pipefail`.
+      test -f /etc/alpine-release || exit 0
+
+      # Redirect bash to ash (built with CONFIG_ASH_BASH_COMPAT) and hope for the best :)
+      # It does support `set -o pipefail`, but not `[[`.
+      # /bin/bash can't be a symlink because /bin/ash is a symlink to /bin/busybox
+      cat >/bin/bash <<'EOF'
+      #!/bin/sh
+      exec /bin/ash "$@"
+      EOF
+      chmod +x /bin/bash
+   owner: root:root
+   path: /var/lib/cloud/scripts/per-boot/00-alpine-ash-as-bash.boot.sh
+   permissions: '0755'
+ - content: |
+      #!/bin/bash
+      set -eux -o pipefail
+
+      # Restrict the rest of this script to Alpine until it has been tested with other distros
+      test -f /etc/alpine-release || exit 0
+
+      # Data directories that should be persisted across reboots
+      DATADIRS="/home /usr/local /etc/containerd /var/lib/containerd"
+
+      # When running from RAM try to move persistent data to data-volume
+      # FIXME: the test for tmpfs mounts is probably Alpine-specific
+      if [ "$(awk '$2 == "/" {print $3}' /proc/mounts)" == "tmpfs" ]; then
+        mkdir -p /mnt/data
+        if [ -e /dev/disk/by-label/data-volume ]; then
+          mount -t ext4 /dev/disk/by-label/data-volume /mnt/data
+        else
+          # Find an unpartitioned disk and create data-volume
+          DISKS=$(lsblk --list --noheadings --output name,type | awk '$2 == "disk" {print $1}')
+          for DISK in ${DISKS}; do
+            IN_USE=false
+            # Looking for a disk that is not mounted or partitioned
+            for PART in $(awk '/^\/dev\// {gsub("/dev/", ""); print $1}' /proc/mounts); do
+              if [ "${DISK}" == "${PART}" -o -e /sys/block/${DISK}/${PART} ]; then
+                IN_USE=true
+                break
+              fi
+            done
+            if [ "${IN_USE}" == "false" ]; then
+              echo 'type=83' | sfdisk --label dos /dev/${DISK}
+              PART=$(lsblk --list /dev/${DISK} --noheadings --output name,type | awk '$2 == "part" {print $1}')
+              mkfs.ext4 -L data-volume /dev/${PART}
+              mount -t ext4 /dev/disk/by-label/data-volume /mnt/data
+              for DIR in ${DATADIRS}; do
+                DEST="/mnt/data$(dirname ${DIR})"
+                mkdir -p ${DIR} ${DEST}
+                mv ${DIR} ${DEST}
+              done
+              break
+            fi
+          done
+        fi
+        for DIR in ${DATADIRS}; do
+          if [ -d /mnt/data${DIR} ]; then
+            [ -e ${DIR} ] && rm -rf ${DIR}
+            ln -s /mnt/data${DIR} ${DIR}
+          fi
+        done
+      fi
+   owner: root:root
+   path: /var/lib/cloud/scripts/per-boot/05-persistent-data-volume.boot.sh
+   permissions: '0755'
+ - content: |
       #!/sbin/openrc-run
       supervisor=supervise-daemon
 
@@ -35,34 +104,24 @@ write_files:
    path: /var/lib/lima-guestagent/lima-guestagent.openrc
    permissions: '0755'
  - content: |
-      #!/bin/sh
-      # This script prepares Alpine for lima; there is nothing in here for other distros
-      test -f /etc/alpine-release || exit
-
-      # Since we are on Alpine, we can now assume /bin/sh is /bin/ash
+      #!/bin/bash
       set -eux -o pipefail
 
-      # Redirect bash to ash (built with CONFIG_ASH_BASH_COMPAT) and hope for the best :)
-      # (it does support `set -o pipefail`, but not `[[`)
-      # /bin/bash can't be a symlink because /bin/ash is a symlink to /bin/busybox
-      cat >/bin/bash <<'EOF'
-      #!/bin/sh
-      exec /bin/ash "$@"
-      EOF
-      chmod +x /bin/bash
+      # This script prepares Alpine for lima; there is nothing in here for other distros
+      test -f /etc/alpine-release || exit 0
 
       # Configure apk repos
-      branch=edge
+      BRANCH=edge
       VERSION_ID=$(awk -F= '$1=="VERSION_ID" {print $2}' /etc/os-release)
-      case $VERSION_ID in
-      *_alpha*|*_beta*) branch=edge;;
-      *.*.*) branch=v${VERSION_ID%.*};;
+      case ${VERSION_ID} in
+      *_alpha*|*_beta*) BRANCH=edge;;
+      *.*.*) BRANCH=v${VERSION_ID%.*};;
       esac
 
-      for repo in main community; do
-        url="https://dl-cdn.alpinelinux.org/alpine/${branch}/${repo}"
-        if ! grep -q "^${url}$" /etc/apk/repositories; then
-          echo "${url}" >> /etc/apk/repositories
+      for REPO in main community; do
+        URL="https://dl-cdn.alpinelinux.org/alpine/${BRANCH}/${REPO}"
+        if ! grep -q "^${URL}$" /etc/apk/repositories; then
+          echo "${URL}" >> /etc/apk/repositories
         fi
       done
 
@@ -85,7 +144,7 @@ write_files:
       rc-update add acpid
       rc-service acpid start
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/00-alpine-prep.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/10-alpine-prep.boot.sh
    permissions: '0755'
  - content: |
       #!/bin/bash
@@ -159,7 +218,7 @@ write_files:
       fi
    owner: root:root
    # We do not use per-once.
-   path: /var/lib/cloud/scripts/per-boot/10-base.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/20-base.boot.sh
    permissions: '0755'
  {{- if or .Mounts .Containerd.System .Containerd.User }}
  - content: |
@@ -210,7 +269,7 @@ write_files:
       fi
       {{- end}}
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/20-install-packages.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/30-install-packages.boot.sh
    permissions: '0755'
 {{- end}}
 {{- if or .Containerd.System .Containerd.User}}
@@ -274,7 +333,7 @@ write_files:
       fi
       {{- end}}
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/30-install-containerd.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/40-install-containerd.boot.sh
    permissions: '0755'
 {{- end}}
 {{- if .Provision}}
@@ -291,7 +350,7 @@ write_files:
       {{- end}}
       {{- end}}
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/40-execute-provision-scripts.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/50-execute-provision-scripts.boot.sh
    permissions: '0755'
 {{- end}}
 {{- range $i, $val := .Provision}}

--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -146,11 +146,14 @@ write_files:
    owner: root:root
    path: /var/lib/cloud/scripts/per-boot/10-alpine-prep.boot.sh
    permissions: '0755'
+ {{- if .Containerd.User}}
  - content: |
       #!/bin/bash
       set -eux -o pipefail
 
-      {{- if .Containerd.User}}
+      # This script does not work unless systemd is available
+      command -v systemctl 2>&1 >/dev/null || exit 0
+
       # Set up env
       for f in .profile .bashrc; do
         if ! grep -q "# Lima BEGIN" "/home/{{.User}}.linux/$f"; then
@@ -194,7 +197,14 @@ write_files:
 
       # Start systemd session
       loginctl enable-linger "{{.User}}"
-      {{- end}}
+   owner: root:root
+   # We do not use per-once.
+   path: /var/lib/cloud/scripts/per-boot/20-rootless-base.boot.sh
+   permissions: '0755'
+ {{- end}}
+ - content: |
+      #!/bin/bash
+      set -eux -o pipefail
 
       # Create mount points
       {{- range $val := .Mounts}}
@@ -218,12 +228,13 @@ write_files:
       fi
    owner: root:root
    # We do not use per-once.
-   path: /var/lib/cloud/scripts/per-boot/20-base.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/25-guestagent-base.boot.sh
    permissions: '0755'
  {{- if or .Mounts .Containerd.System .Containerd.User }}
  - content: |
       #!/bin/bash
       set -eux -o pipefail
+
       # Install minimum dependencies
       if command -v apt-get 2>&1 >/dev/null; then
         export DEBIAN_FRONTEND=noninteractive
@@ -276,6 +287,10 @@ write_files:
  - content: |
       #!/bin/bash
       set -eux -o pipefail
+
+      # This script does not work unless systemd is available
+      command -v systemctl 2>&1 >/dev/null || exit 0
+
       if [ ! -x /usr/local/bin/nerdctl ]; then
         mkdir -p -m 600 /mnt/lima-cidata
         mount -t iso9660 -o ro /dev/disk/by-label/cidata /mnt/lima-cidata

--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -19,6 +19,75 @@ users:
 
 write_files:
  - content: |
+      #!/sbin/openrc-run
+      supervisor=supervise-daemon
+
+      name="lima-guestagent"
+      description="Forward ports to the lima-hostagent"
+
+      export XDG_RUNTIME_DIR="/run/user/{{.UID}}"
+      command=/usr/local/bin/lima-guestagent
+      command_args="daemon"
+      command_background=true
+      command_user="{{.User}}:{{.User}}"
+      pidfile="${XDG_RUNTIME_DIR}/lima-guestagent.pid"
+   owner: root:root
+   path: /var/lib/lima-guestagent/lima-guestagent.openrc
+   permissions: '0755'
+ - content: |
+      #!/bin/sh
+      # This script prepares Alpine for lima; there is nothing in here for other distros
+      test -f /etc/alpine-release || exit
+
+      # Since we are on Alpine, we can now assume /bin/sh is /bin/ash
+      set -eux -o pipefail
+
+      # Redirect bash to ash (built with CONFIG_ASH_BASH_COMPAT) and hope for the best :)
+      # (it does support `set -o pipefail`, but not `[[`)
+      # /bin/bash can't be a symlink because /bin/ash is a symlink to /bin/busybox
+      cat >/bin/bash <<'EOF'
+      #!/bin/sh
+      exec /bin/ash "$@"
+      EOF
+      chmod +x /bin/bash
+
+      # Configure apk repos
+      branch=edge
+      VERSION_ID=$(awk -F= '$1=="VERSION_ID" {print $2}' /etc/os-release)
+      case $VERSION_ID in
+      *_alpha*|*_beta*) branch=edge;;
+      *.*.*) branch=v${VERSION_ID%.*};;
+      esac
+
+      for repo in main community; do
+        url="https://dl-cdn.alpinelinux.org/alpine/${branch}/${repo}"
+        if ! grep -q "^${url}$" /etc/apk/repositories; then
+          echo "${url}" >> /etc/apk/repositories
+        fi
+      done
+
+      # Alpine doesn't use PAM so we need to explicitly allow public key auth
+      usermod -p '*' ""{{.User}}""
+
+      # Alpine disables TCP forwarding, which is needed by the lima-guestagent
+      sed -i 's/AllowTcpForwarding no/AllowTcpForwarding yes/g' /etc/ssh/sshd_config
+      rc-service sshd reload
+
+      # Create directory for the lima-guestagent socket (normally done by systemd)
+      mkdir -p /run/user/{{.UID}}
+      chown "{{.User}}" /run/user/{{.UID}}
+      chmod 700 /run/user/{{.UID}}
+
+      # Install the openrc lima-guestagent service script
+      mv /var/lib/lima-guestagent/lima-guestagent.openrc /etc/init.d/lima-guestagent
+
+      # `limactl stop` tells acpid to powerdown
+      rc-update add acpid
+      rc-service acpid start
+   owner: root:root
+   path: /var/lib/cloud/scripts/per-boot/00-alpine-prep.boot.sh
+   permissions: '0755'
+ - content: |
       #!/bin/bash
       set -eux -o pipefail
 
@@ -81,11 +150,16 @@ write_files:
       umount /mnt/lima-cidata
 
       # Launch the guestagent service
-      until [ -e "/run/user/{{.UID}}/systemd/private" ]; do sleep 3; done
-      sudo -iu "{{.User}}" "XDG_RUNTIME_DIR=/run/user/{{.UID}}" lima-guestagent install-systemd
+      if [ -f /etc/alpine-release ]; then
+        rc-update add lima-guestagent default
+        rc-service lima-guestagent start
+      else
+        until [ -e "/run/user/{{.UID}}/systemd/private" ]; do sleep 3; done
+        sudo -iu "{{.User}}" "XDG_RUNTIME_DIR=/run/user/{{.UID}}" lima-guestagent install-systemd
+      fi
    owner: root:root
    # We do not use per-once.
-   path: /var/lib/cloud/scripts/per-boot/00-base.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/10-base.boot.sh
    permissions: '0755'
  {{- if or .Mounts .Containerd.System .Containerd.User }}
  - content: |
@@ -119,6 +193,15 @@ write_files:
           ln -s fusermount3 /usr/bin/fusermount
         fi
         {{- end}}
+      elif command -v apk 2>&1 >/dev/null; then
+        : {{/* make sure the "elif" block is never empty */}}
+        {{- if .Mounts}}
+        if ! command -v sshfs 2>&1 >/dev/null; then
+          apk update
+          apk add sshfs
+        fi
+        modprobe fuse
+        {{- end}}
       fi
       # Modify /etc/fuse.conf to allow "-o allow_root"
       {{- if .Mounts }}
@@ -127,7 +210,7 @@ write_files:
       fi
       {{- end}}
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/10-install-packages.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/20-install-packages.boot.sh
    permissions: '0755'
 {{- end}}
 {{- if or .Containerd.System .Containerd.User}}
@@ -191,7 +274,7 @@ write_files:
       fi
       {{- end}}
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/20-install-containerd.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/30-install-containerd.boot.sh
    permissions: '0755'
 {{- end}}
 {{- if .Provision}}
@@ -208,7 +291,7 @@ write_files:
       {{- end}}
       {{- end}}
    owner: root:root
-   path: /var/lib/cloud/scripts/per-boot/30-execute-provision-scripts.boot.sh
+   path: /var/lib/cloud/scripts/per-boot/40-execute-provision-scripts.boot.sh
    permissions: '0755'
 {{- end}}
 {{- range $i, $val := .Provision}}

--- a/pkg/hostagent/requirements.go
+++ b/pkg/hostagent/requirements.go
@@ -100,7 +100,7 @@ fi
 		script: `#!/bin/bash
 set -eux -o pipefail
 sock="/run/user/$(id -u)/lima-guestagent.sock"
-if ! timeout 30s bash -c "until [[ -S \"${sock}\" ]]; do sleep 3; done"; then
+if ! timeout 30s bash -c "until [ -S \"${sock}\" ]; do sleep 3; done"; then
 	echo >&2 "lima-guestagent is not installed yet"
 	exit 1
 fi

--- a/pkg/iso9660util/iso9660util.go
+++ b/pkg/iso9660util/iso9660util.go
@@ -60,3 +60,18 @@ func WriteFile(fs filesystem.FileSystem, path string, r io.Reader) (int64, error
 	defer f.Close()
 	return io.Copy(f, r)
 }
+
+func IsISO9660(imagePath string) (bool, error) {
+	imageFile, err := os.Open(imagePath)
+	if err != nil {
+		return false, err
+	}
+	defer imageFile.Close()
+
+	fileInfo, err := imageFile.Stat()
+	if err != nil {
+		return false, err
+	}
+	_, err = iso9660.Read(imageFile, fileInfo.Size(), 0, 0)
+	return err == nil, nil
+}


### PR DESCRIPTION
Requires Alpine image with cloud-init, but configures lima-guestagent service with openrc and pretends /bin/ash can stand in for /bin/bash.

Does not work with containerd; not sure where to put the OpenRC scripts for it (maybe nerdctl?).

###### *Persistent disk when booting from ISO image*

When booting from a LiveCD image there is no point in generating a `diffDisk` because the OS is running from RAM, not from the disk.

In that case just add `diffDisk` as an independent data volume and move directories that should be persisted on there. Currently: `/home`, `/usr/local`, `/etc/containerd`, and `/var/lib/containerd`.

This `data-volume` logic is currently only enabled for Alpine because it hasn't been tested anywhere else yet.

Additional, if the configured disk size is 0, no `diffDisk` will be allocated and changes will be written back to the `baseDisk` (or discarded, if the `baseDisk` is an ISO image).

### This is still WIP

Things seem to be working fine, except `limactl stop` so far doesn't manage to shut down Alpine gracefully.