### PR TITLE
Implement LIMA_HOME to override ~/.lima location

### DIFF
--- a/cmd/limactl/start.go
+++ b/cmd/limactl/start.go
@@ -82,6 +82,12 @@ func loadOrCreateInstance(clicontext *cli.Context) (*store.Instance, error) {
 		return nil, err
 	}
 
+	// all socket names should be 6 characters or less
+	maxSockName := filepath.Join(instDir, "serial.sock")
+	if len(maxSockName) >= 104 {
+		return nil, errors.Errorf("Instance name %q too long: %q must be less than 104 characers, but is %d",
+			instName, maxSockName, len(maxSockName))
+	}
 	if _, err := os.Stat(instDir); !errors.Is(err, os.ErrNotExist) {
 		return nil, errors.Errorf("instance %q already exists (%q)", instName, instDir)
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -12,17 +12,20 @@ import (
 // DotLima is a directory that appears under the home directory.
 const DotLima = ".lima"
 
-// LimaDir returns the abstract path of `~/.lima`.
+// LimaDir returns the abstract path of `~/.lima` (or $LIMA_HOME, if set).
 //
 // NOTE: We do not use `~/Library/Application Support/Lima` on macOS.
 // We use `~/.lima` so that we can have enough space for the length of the socket path,
 // which can be only 104 characters on macOS.
 func LimaDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+	dir := os.Getenv("LIMA_HOME")
+	if dir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(homeDir, DotLima)
 	}
-	dir := filepath.Join(homeDir, DotLima)
 	return dir, nil
 }
 


### PR DESCRIPTION
The `limactl start` command now verifies that the combination of LimaDir, instance name, and longest socket name is less than 104 characters, and refuses to create the instance otherwise.

This is intended for applications that want to use lima internally to manage Linux VMs, and don't want to mix those with the VMs managed by the user directly (e.g. [Rancher Desktop](https://github.com/rancher-sandbox/rancher-desktop)).