### PR TITLE
Make sure /sys/fs/cgroup is mounted on Alpine for container support

### DIFF
--- a/pkg/cidata/user-data.TEMPLATE
+++ b/pkg/cidata/user-data.TEMPLATE
@@ -140,6 +140,9 @@ write_files:
       # Install the openrc lima-guestagent service script
       mv /var/lib/lima-guestagent/lima-guestagent.openrc /etc/init.d/lima-guestagent
 
+      # mount /sys/fs/cgroup
+      rc-service cgroups start
+
       # `limactl stop` tells acpid to powerdown
       rc-update add acpid
       rc-service acpid start


### PR DESCRIPTION
Fixes #66 

Normally this would be done by the openrc script for containerd, e.g. https://github.com/alpinelinux/aports/blob/master/community/containerd/containerd.initd#L22-L24

Signed-off-by: Jan Dubois <jan.dubois@suse.com>