### PR TITLE
Don't try to remove host keys when ~/.ssh/known_hosts doesn't exist

### DIFF
--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -159,12 +159,9 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	}
 	stBooting := stBase
 	a.emitEvent(ctx, hostagentapi.Event{Status: stBooting})
-	sshFixCmd := exec.Command("ssh-keygen",
-		"-R", fmt.Sprintf("[127.0.0.1]:%d", sshLocalPort),
-		"-R", fmt.Sprintf("[localhost]:%d", sshLocalPort),
-	)
-	if out, err := sshFixCmd.CombinedOutput(); err != nil {
-		return errors.Wrapf(err, "failed to run %v: %q", sshFixCmd.Args, string(out))
+	if err := sshutil.RemoveKnownHostEntries(sshLocalPort); err != nil {
+		a.l.WithError(err).Error("couldn't remove existing localhost host keys")
+		return err
 	}
 
 	go func() {


### PR DESCRIPTION
`ssh-keygen -R` will exit with a non-0 status and the hostagent would abort. If the file doesn't exist, then there isn't anything to do.
