### PR TITLE
Extract minimal set of lima and qemu files to install on a clean machine

### DIFF
--- a/hack/lima-and-qemu.pl
+++ b/hack/lima-and-qemu.pl
@@ -1,0 +1,155 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use FindBin qw();
+
+# By default capture both legacy firmware (alpine) and UFI (default) usage
+@ARGV = qw(alpine default) unless @ARGV;
+
+# This script creates a tarball containing lima and qemu, plus all their
+# dependencies from /usr/local/**.
+#
+# New processes (with their command line arguments) have been captured by
+# `sudo dtrace -s /usr/bin/newproc.d` (on a system with SIP disabled, using lima 0.3.0):
+# `limactl start examples/alpine.yaml; limactl stop alpine; limactrl delete alpine`.
+#
+# 5680 <777>  limactl start --tty=false examples/alpine.yaml
+# 5681 <5680> curl -fSL -o /Users/jan/Library/Caches/lima/download/by-url-sha256/21753<...>
+# 5683 <5680> qemu-img create -f qcow2 /Users/jan/.lima/alpine/diffdisk 107374182400
+# 5684 <5680> /usr/local/bin/limactl hostagent --pidfile /Users/jan/.lima/alpine/ha.pid alpine
+# 5686 <5684> ssh-keygen -R [127.0.0.1]:60020 -R [localhost]:60020
+# 5687 <5684> ssh -o ControlMaster=auto -o ControlPath=/Users/jan/.lima/alpine/ssh.sock -o <...>
+# 5685 <5684> /usr/local/bin/qemu-system-x86_64 -cpu Haswell-v4 -machine q35,accel=hvf -smp <...>
+# 5689 <5684> ssh -o ControlMaster=auto -o ControlPath=/Users/jan/.lima/alpine/ssh.sock -o <...>
+# ... many more ssh sub-processes like the one above ...
+# 5800 <777>  limactl stop alpine
+# 5801 <5684> ssh -o ControlMaster=auto -o ControlPath=/Users/jan/.lima/alpine/ssh.sock -o <...>
+# 5896 <777>  limactl delete alpine
+#
+# It shows the following binaries from /usr/local are called:
+
+my $install_dir = "/usr/local";
+record("$install_dir/bin/limactl");
+record("$install_dir/bin/qemu-img");
+record("$install_dir/bin/qemu-system-x86_64");
+
+# Capture any library and datafiles access with opensnoop
+my $opensnoop = "/tmp/opensnoop.log";
+END { system("sudo pkill dtrace") }
+print "sudo may prompt for password to run opensnoop\n";
+system("sudo -b opensnoop >$opensnoop 2>/dev/null");
+sleep(1) until -s $opensnoop;
+
+my $repo_root = dirname($FindBin::Bin);
+for my $example (@ARGV) {
+    my $config = "$repo_root/examples/$example.yaml", ;
+    die "Config $config not found" unless -f $config;
+    system("limactl delete -f $example") if -f "$ENV{HOME}/.lima/$example";
+    system("limactl start --tty=false $config");
+    system("limactl shell $example uname");
+    system("limactl stop $example");
+    system("limactl delete $example");
+}
+system("sudo pkill dtrace");
+
+open(my $fh, "<", $opensnoop) or die "Can't read $opensnoop: $!";
+while (<$fh>) {
+    # Only record files opened by limactl or qemu-*
+    next unless /^\s*\d+\s+\d+\s+(limactl|qemu-)/;
+    # Ignore files not under /usr/local
+    next unless s|^.*($install_dir/\S+).*$|$1|s;
+    # Skip files that don't exist
+    next unless -f;
+    record($_);
+}
+
+my %deps;
+print "$_ $deps{$_}\n" for sort keys %deps;
+print "\n";
+
+my $dist = "lima-and-qemu";
+system("rm -rf /tmp/$dist");
+
+# Copy all files to /tmp tree and make all dylib references relative to the
+# /usr/local/bin directory using @executable_path/..
+my %resign;
+for my $file (keys %deps) {
+    my $copy = $file =~ s|^$install_dir|/tmp/$dist|r;
+    system("mkdir -p " . dirname($copy));
+    system("cp -R $file $copy");
+    next if -l $file;
+    next unless qx(file $copy) =~ /Mach-O/;
+
+    open(my $fh, "otool -L $file |") or die "Failed to run 'otool -L $file': $!";
+    while (<$fh>) {
+        my($dylib) = m|$install_dir/(\S+)| or next;
+        my $grep = "";
+        if ($file =~ m|bin/qemu-system-x86_64$|) {
+            # qemu-system-* is already signed with an entitlement to use the hypervisor framework
+            $grep = "| grep -v 'will invalidate the code signature'";
+            $resign{$copy}++;
+        }
+        system "install_name_tool -change $install_dir/$dylib \@executable_path/../$dylib $copy 2>&1 $grep";
+    }
+    close($fh);
+}
+# Replace invalidated signatures
+for my $file (keys %resign) {
+    system("codesign --sign - --force --preserve-metadata=entitlements $file");
+}
+
+unlink("$repo_root/$dist.tar.gz");
+my $files = join(" ", map s|^$install_dir/||r, keys %deps);
+system("tar cvfz $repo_root/$dist.tar.gz -C /tmp/$dist $files");
+exit;
+
+# File references may involve multiple symlinks that need to be recorded as well, e.g.
+#
+#   /usr/local/opt/libssh/lib/libssh.4.dylib
+#
+# turns into 2 symlinks and one file:
+#
+#   /usr/local/opt/libssh → ../Cellar/libssh/0.9.5_1
+#   /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.dylib → libssh.4.8.6.dylib
+#   /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib [394K]
+
+my %seen;
+sub record {
+    my $dep = shift;
+    return if $seen{$dep}++;
+    $dep =~ s|^/|| or die "$dep is not an absolute path";
+    my $filename = "";
+    my @segments = split '/', $dep;
+    while (@segments) {
+        my $segment = shift @segments;
+        my $name = "$filename/$segment";
+        my $link = readlink $name;
+        if (defined $link) {
+            # Record the symlink itself with the link target as the comment
+            $deps{$name} = "→ $link";
+            if ($link =~ m|^/|) {
+                # Can't support absolute links pointing outside /usr/local
+                die "$name → $link" unless $link =~ m|^$install_dir/|;
+                $link = join("/", $link, @segments);
+            } else {
+                $link = join("/", $filename, $link, @segments);
+            }
+            # Re-parse from the start because the link may contain ".." segments
+            return record($link)
+        }
+        if ($segment eq "..") {
+            $filename = dirname($filename);
+        } else {
+            $filename = $name;
+        }
+    }
+    # Use human readable size of the file as the comment:
+    # $ ls -lh /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib
+    # -rw-r--r--  1 jan  staff   394K  5 Jan 11:04 /usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib
+    $deps{$filename} = sprintf "[%s]", (split / +/, qx(ls -lh $filename))[4];
+}
+
+sub dirname {
+    shift =~ s|/[^/]+$||r;
+}


### PR DESCRIPTION
Installing qemu via homebrew installs 846MB of stuff under `/usr/local/Cellar`, 571MB of which are the `qemu` cellar alone.

This is clearly excessive for bundling `lima` with an app that simply wants to deploy VMs.

The attached script uses dtrace to observe which files are actually opened by `lima` and `qemu`, and then collects just those. It collects the corresponding symlinks and also modifies all Mach-O binaries to reference dylibs relative to the path of the executable, so the files can be relocated anywhere (the `/usr/local` prefix is stripped from all filenames).

There are still hard-coded paths to things under /usr/local inside the binaries, but testing shows that lima works with the bundled files as-is on a freshly installed Catalina VM (from memory, so may contain typos):

```console
$ ssh-keygen
(enter, enter, enter)
$ touch ~/.ssh/known_hosts
$ mkdir ~/lima
$ cd ~/lima
$ tar xfvz ~/Downloads/lima-and-qemu.tar.gz
$ export PATH=~/lima/bin:$PATH
$ limactl start --tty=false
```

<details><summary>Compressed tarball is 18MB and contains the following files</summary>

/usr/local/Cellar/gettext/0.21/lib/libintl.8.dylib [58K]
/usr/local/Cellar/glib/2.68.3/lib/libgio-2.0.0.dylib [1.7M]
/usr/local/Cellar/glib/2.68.3/lib/libglib-2.0.0.dylib [1.2M]
/usr/local/Cellar/glib/2.68.3/lib/libgmodule-2.0.0.dylib [51K]
/usr/local/Cellar/glib/2.68.3/lib/libgobject-2.0.0.dylib [336K]
/usr/local/Cellar/gmp/6.2.1/lib/libgmp.10.dylib [437K]
/usr/local/Cellar/gnutls/3.6.16/lib/libgnutls.30.dylib [1.6M]
/usr/local/Cellar/jpeg/9d/lib/libjpeg.9.dylib [214K]
/usr/local/Cellar/libffi/3.3_3/lib/libffi.7.dylib [69K]
/usr/local/Cellar/libidn2/2.3.1/lib/libidn2.0.dylib [167K]
/usr/local/Cellar/libpng/1.6.37/lib/libpng16.16.dylib [173K]
/usr/local/Cellar/libslirp/4.6.1/lib/libslirp.0.dylib [160K]
/usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.8.6.dylib [394K]
/usr/local/Cellar/libssh/0.9.5_1/lib/libssh.4.dylib → libssh.4.8.6.dylib
/usr/local/Cellar/libtasn1/4.17.0/lib/libtasn1.6.dylib [103K]
/usr/local/Cellar/libunistring/0.9.10/lib/libunistring.2.dylib [1.5M]
/usr/local/Cellar/libusb/1.0.24/lib/libusb-1.0.0.dylib [136K]
/usr/local/Cellar/lzo/2.10/lib/liblzo2.2.dylib [113K]
/usr/local/Cellar/ncurses/6.2/lib/libncursesw.6.dylib [306K]
/usr/local/Cellar/nettle/3.7.3/lib/libhogweed.6.4.dylib [289K]
/usr/local/Cellar/nettle/3.7.3/lib/libhogweed.6.dylib → libhogweed.6.4.dylib
/usr/local/Cellar/nettle/3.7.3/lib/libnettle.8.4.dylib [268K]
/usr/local/Cellar/nettle/3.7.3/lib/libnettle.8.dylib → libnettle.8.4.dylib
/usr/local/Cellar/openssl@1.1/1.1.1k/lib/libcrypto.1.1.dylib [2.3M]
/usr/local/Cellar/p11-kit/0.24.0/lib/libp11-kit.0.dylib [975K]
/usr/local/Cellar/pcre/8.45/lib/libpcre.1.dylib [474K]
/usr/local/Cellar/pixman/0.40.0/lib/libpixman-1.0.40.0.dylib [550K]
/usr/local/Cellar/pixman/0.40.0/lib/libpixman-1.0.dylib → libpixman-1.0.40.0.dylib
/usr/local/Cellar/qemu/6.0.0/bin/qemu-img [1.4M]
/usr/local/Cellar/qemu/6.0.0/bin/qemu-system-x86_64 [13M]
/usr/local/Cellar/qemu/6.0.0/share/qemu/bios-256k.bin [256K]
/usr/local/Cellar/qemu/6.0.0/share/qemu/edk2-x86_64-code.fd [3.5M]
/usr/local/Cellar/qemu/6.0.0/share/qemu/efi-virtio.rom [157K]
/usr/local/Cellar/qemu/6.0.0/share/qemu/kvmvapic.bin [9.0K]
/usr/local/Cellar/qemu/6.0.0/share/qemu/vgabios-virtio.bin [39K]
/usr/local/Cellar/snappy/1.1.9/lib/libsnappy.1.1.9.dylib [74K]
/usr/local/Cellar/snappy/1.1.9/lib/libsnappy.1.dylib → libsnappy.1.1.9.dylib
/usr/local/Cellar/vde/2.3.2_1/lib/libvdeplug.3.dylib [52K]
/usr/local/bin/limactl [10M]
/usr/local/bin/qemu-img → ../Cellar/qemu/6.0.0/bin/qemu-img
/usr/local/bin/qemu-system-x86_64 → ../Cellar/qemu/6.0.0/bin/qemu-system-x86_64
/usr/local/opt/gettext → ../Cellar/gettext/0.21
/usr/local/opt/glib → ../Cellar/glib/2.68.3
/usr/local/opt/gmp → ../Cellar/gmp/6.2.1
/usr/local/opt/gnutls → ../Cellar/gnutls/3.6.16
/usr/local/opt/jpeg → ../Cellar/jpeg/9d
/usr/local/opt/libffi → ../Cellar/libffi/3.3_3
/usr/local/opt/libidn2 → ../Cellar/libidn2/2.3.1
/usr/local/opt/libpng → ../Cellar/libpng/1.6.37
/usr/local/opt/libslirp → ../Cellar/libslirp/4.6.1
/usr/local/opt/libssh → ../Cellar/libssh/0.9.5_1
/usr/local/opt/libtasn1 → ../Cellar/libtasn1/4.17.0
/usr/local/opt/libunistring → ../Cellar/libunistring/0.9.10
/usr/local/opt/libusb → ../Cellar/libusb/1.0.24
/usr/local/opt/lzo → ../Cellar/lzo/2.10
/usr/local/opt/ncurses → ../Cellar/ncurses/6.2
/usr/local/opt/nettle → ../Cellar/nettle/3.7.3
/usr/local/opt/openssl@1.1 → ../Cellar/openssl@1.1/1.1.1k
/usr/local/opt/p11-kit → ../Cellar/p11-kit/0.24.0
/usr/local/opt/pcre → ../Cellar/pcre/8.45
/usr/local/opt/pixman → ../Cellar/pixman/0.40.0
/usr/local/opt/snappy → ../Cellar/snappy/1.1.9
/usr/local/opt/vde → ../Cellar/vde/2.3.2_1
/usr/local/share/lima/lima-guestagent.Linux-x86_64 [6.6M]
/usr/local/share/qemu → ../Cellar/qemu/6.0.0/share/qemu
</details>

@AkihiroSuda I'm not sure if you want this script in your repo; let me know. I probably need a place to host downloadable bits for Rancher Desktop elsewhere anyways, as we'll eventually need to sign the bits (at least for ARM), and probably want to build from source, eventually. So I could always keep the script in a separate repo.