### PR TITLE
allow overriding qemu binary ($QEMU_SYSTEM_X86_64, $QEMU_SYSTEM_AARCH64)

### DIFF
--- a/docs/internal.md
+++ b/docs/internal.md
@@ -59,6 +59,12 @@ The directory contains the following files:
 - `$LIMA_INSTANCE`: `lima ...` is expanded to `limactl shell ${LIMA_INSTANCE} ...`.
   - Default : `default`
 
+- `$QEMU_SYSTEM_X86_64`: path of `qemu-system-x86_64`
+  - Default: `qemu-system-x86_64` in `$PATH`
+
+- `$QEMU_SYSTEM_AARCH64`: path of `qemu-system-aarch64`
+  - Default: `qemu-system-aarch64` in `$PATH`
+
 ## `cidata.iso`
 `cidata.iso` contains the following files:
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-isatty v0.0.13
+	github.com/mattn/go-shellwords v1.0.12
 	github.com/norouter/norouter v0.6.3
 	github.com/nxadm/tail v1.4.8
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,8 @@ github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1y
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -133,12 +133,12 @@ func (a *HostAgent) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer logPipeRoutine(a.l, qStdout, "qemu[stdout]")
+	go logPipeRoutine(a.l, qStdout, "qemu[stdout]")
 	qStderr, err := qCmd.StderrPipe()
 	if err != nil {
 		return err
 	}
-	defer logPipeRoutine(a.l, qStderr, "qemu[stderr]")
+	go logPipeRoutine(a.l, qStderr, "qemu[stderr]")
 
 	a.l.Infof("Starting QEMU (hint: to watch the boot progress, see %q)", filepath.Join(a.instDir, filenames.SerialLog))
 	a.l.Debugf("qCmd.Args: %v", qCmd.Args)

--- a/pkg/qemu/qemu_test.go
+++ b/pkg/qemu/qemu_test.go
@@ -1,0 +1,49 @@
+package qemu
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestArgValue(t *testing.T) {
+	type testCase struct {
+		key           string
+		expectedValue string
+		expectedOK    bool
+	}
+	args := []string{"-cpu", "foo", "-no-reboot", "-m", "2G", "-s"}
+	testCases := []testCase{
+		{
+			key:           "-cpu",
+			expectedValue: "foo",
+			expectedOK:    true,
+		},
+		{
+			key:           "-no-reboot",
+			expectedValue: "",
+			expectedOK:    true,
+		},
+		{
+			key:           "-m",
+			expectedValue: "2G",
+			expectedOK:    true,
+		},
+		{
+			key:           "-machine",
+			expectedValue: "",
+			expectedOK:    false,
+		},
+		{
+			key:           "-s",
+			expectedValue: "",
+			expectedOK:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		v, ok := argValue(args, tc.key)
+		assert.Equal(t, tc.expectedValue, v)
+		assert.Equal(t, tc.expectedOK, ok)
+	}
+}


### PR DESCRIPTION
Passing args is also possible (only for debugging purpose), e.g., "QEMU_SYSTEM_X86_64=/opt/qemu/bin/qemu-system-x86_64 -snapshot" .

Fix #27 
Fix #14