### PR TITLE
Use user identify from $LIMA_HOME/_config/user

### DIFF
--- a/docs/internal.md
+++ b/docs/internal.md
@@ -9,6 +9,19 @@ Note that we intentionally avoid using `~/Library/Application Support/Lima` on m
 We use `~/.lima` so that we can have enough space for the length of the socket path,
 which must be less than 104 characters on macOS.
 
+### Config directory (`${LIMA_HOME}/_config`)
+
+The config directory contains global lima settings that apply to all instances.
+
+User identity:
+
+Lima creates a default identity and uses its public key as the authorized key
+to access all lima instances. In addition lima will also configure all public
+keys from `~/.ssh/*.pub` as well, so the user can use the ssh endpoint without
+having to specify an identity explicitly.
+- `user`: private key
+- `user.pub`: public key
+
 ### Instance directory (`${LIMA_HOME}/<INSTANCE>`)
 
 An instance directory contains the following files:

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -41,7 +41,10 @@ func GenerateISO9660(isoPath, name string, y *limayaml.LimaYAML) error {
 		Containerd: Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
 	}
 
-	pubKeys := sshutil.DefaultPubKeys()
+	pubKeys, err := sshutil.DefaultPubKeys()
+	if err != nil {
+		return err
+	}
 	if len(pubKeys) == 0 {
 		return errors.New("no SSH key was found, run `ssh-keygen`")
 	}

--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/AkihiroSuda/lima/pkg/osutil"
+	"github.com/AkihiroSuda/lima/pkg/store"
 	"github.com/AkihiroSuda/lima/pkg/store/filenames"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -19,34 +20,71 @@ type PubKey struct {
 	Content  string
 }
 
-// DefaultPubKeys finds ssh public keys from ~/.ssh
-func DefaultPubKeys() []PubKey {
+func readPublicKey(f string) (PubKey, error) {
+	entry := PubKey{
+		Filename: f,
+	}
+	content, err := os.ReadFile(f)
+	if err == nil {
+		entry.Content = strings.TrimSpace(string(content))
+	} else {
+		err = errors.Wrapf(err, "failed to read ssh public key %q", f)
+	}
+	return entry, err
+}
+
+// DefaultPubKeys returns the public key from $LIMA_HOME/_config/user.pub.
+// The key will be created if it does not yet exist. All public keys
+// ~/.ssh/*.pub will be appended to make the VM accessible without specifying
+// and identity explicitly.
+func DefaultPubKeys() ([]PubKey, error) {
+	// Read $LIMA_HOME/_config/user.pub
+	configDir, err := store.LimaConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	_, err = os.Stat(filepath.Join(configDir, filenames.UserPrivateKey))
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if err := os.MkdirAll(configDir, 0700); err != nil {
+			return nil, errors.Wrapf(err, "could not create %q directory", configDir)
+		}
+		keygenCmd := exec.Command("ssh-keygen", "-t", "ed25519", "-q", "-N", "", "-f",
+			filepath.Join(configDir, filenames.UserPrivateKey))
+		logrus.Debugf("executing %v", keygenCmd.Args)
+		if out, err := keygenCmd.CombinedOutput(); err != nil {
+			return nil, errors.Wrapf(err, "failed to run %v: %q", keygenCmd.Args, string(out))
+		}
+	}
+	entry, err := readPublicKey(filepath.Join(configDir, filenames.UserPublicKey))
+	if err != nil {
+		return nil, err
+	}
+	res := []PubKey{entry}
+
+	// Append all of ~/.ssh/*.pub
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		logrus.Warn(err)
-		return nil
+		return nil, err
 	}
 	files, err := filepath.Glob(filepath.Join(homeDir, ".ssh/*.pub"))
 	if err != nil {
-		logrus.Warn(err)
-		return nil
+		panic(err) // Only possible error is ErrBadPattern, so this should be unreachable.
 	}
-	var res []PubKey
 	for _, f := range files {
 		if !strings.HasSuffix(f, ".pub") {
 			panic(errors.Errorf("unexpected ssh public key filename %q", f))
 		}
-		entry := PubKey{
-			Filename: f,
+		entry, err := readPublicKey(f)
+		if err == nil {
+			res = append(res, entry)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
 		}
-		if content, err := os.ReadFile(f); err == nil {
-			entry.Content = strings.TrimSpace(string(content))
-		} else {
-			logrus.WithError(err).Warningf("failed to read ssh public key %q", f)
-		}
-		res = append(res, entry)
 	}
-	return res
+	return res, nil
 }
 
 func RemoveKnownHostEntries(sshLocalPort int) error {
@@ -77,7 +115,17 @@ func SSHArgs(instDir string) ([]string, error) {
 	if len(controlSock) >= osutil.UnixPathMax {
 		return nil, errors.Errorf("socket path %q is too long: >= UNIX_PATH_MAX=%d", controlSock, osutil.UnixPathMax)
 	}
+	configDir, err := store.LimaConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	privateKeyPath := filepath.Join(configDir, filenames.UserPrivateKey)
+	_, err = os.Stat(privateKeyPath)
+	if err != nil {
+		return nil, err
+	}
 	args := []string{
+		"-i", privateKeyPath,
 		"-l", u.Username, // guest and host have the same username, but we should specify the username explicitly (#85)
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + controlSock,

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -3,7 +3,7 @@ package sshutil
 import "testing"
 
 func TestDefaultPubKeys(t *testing.T) {
-	keys := DefaultPubKeys()
+	keys, _ := DefaultPubKeys()
 	t.Logf("found %d public keys", len(keys))
 	for _, key := range keys {
 		t.Logf("%s: %q", key.Filename, key.Content)

--- a/pkg/store/filenames/filenames.go
+++ b/pkg/store/filenames/filenames.go
@@ -1,7 +1,24 @@
-// Package filenames defines the names of the files that appear under an instance dir.
+// Package filenames defines the names of the files that appear under an instance dir
+// or inside the config directory.
 //
 // See docs/internal.md .
 package filenames
+
+// Instance names starting with an underscore are reserved for lima internal usage
+
+const (
+	ConfigDir = "_config"
+	CacheDir  = "_cache" // not yet implemented
+)
+
+// Filenames used inside the ConfigDir
+
+const (
+	UserPrivateKey = "user"
+	UserPublicKey  = UserPrivateKey + ".pub"
+)
+
+// Filenames that may appear under an instance directory
 
 const (
 	LimaYAML           = "lima.yaml"

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/AkihiroSuda/lima/pkg/store/filenames"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,15 @@ func LimaDir() (string, error) {
 		dir = filepath.Join(homeDir, DotLima)
 	}
 	return dir, nil
+}
+
+// LimaConfigDir returns the path of the config directory, $LIMA_HOME/_config.
+func LimaConfigDir() (string, error) {
+	limaDir, err := LimaDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(limaDir, filenames.ConfigDir), nil
 }
 
 // Instances returns the names of the instances under LimaDir.


### PR DESCRIPTION
By default lima uses the public keys from `~/.ssh/*.pub`.

This change makes it try `$LIME_HOME/_config/user.pub` first and only fall back on the `~/.ssh/*.pub` keys when that one does not exist. It will create the key under `$LIMA_HOME/_config` if there aren't any public keys under `~/.ssh`.

Fixes #78 