### PR TITLE
Add openSUSE example config (using JeOS image for OpenStack).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        example: [default.yaml, alpine.yaml, debian.yaml, fedora.yaml, archlinux.yaml]
+        example: [default.yaml, alpine.yaml, debian.yaml, fedora.yaml, archlinux.yaml, opensuse.yaml]
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/examples/opensuse.yaml
+++ b/examples/opensuse.yaml
@@ -1,0 +1,13 @@
+images:
+  - location: https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-OpenStack-Cloud-Build9.108.qcow2
+    arch: "x86_64"
+  # No aarch64 OpenStack build found :(
+mounts:
+  - location: "~"
+    writable: false
+  - location: "/tmp/lima"
+    writable: true
+ssh:
+  # localPort is changed from 60022 to avoid conflicting with the default.
+  # (TODO: assign localPort automatically)
+  localPort: 60044

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/30-install-packages.sh
@@ -57,6 +57,22 @@ elif command -v pacman >/dev/null 2>&1; then
 		fi
 	fi
 	# other dependencies are preinstalled on Arch Linux (https://linuximages.de/openstack/arch/)
+elif command -v zypper >/dev/null 2>&1; then
+	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ]; then
+		if ! command -v sshfs >/dev/null 2>&1; then
+			zypper install -y sshfs
+		fi
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_SYSTEM}" = 1 ] || [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+		if [ ! -e /usr/sbin/iptables ]; then
+			zypper install -y iptables
+		fi
+	fi
+	if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
+		if ! command -v mount.fuse3 >/dev/null 2>&1; then
+			zypper install -y fuse3
+		fi
+	fi
 elif command -v apk >/dev/null 2>&1; then
 	if [ "${LIMA_CIDATA_MOUNTS}" -gt 0 ]; then
 		if ! command -v sshfs >/dev/null 2>&1; then

--- a/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh
@@ -26,6 +26,7 @@ fi
 
 if [ "${LIMA_CIDATA_CONTAINERD_USER}" = 1 ]; then
 	modprobe tap || true
+	modprobe ip_tables || true
 	if [ ! -e "/home/${LIMA_CIDATA_USER}.linux/.config/containerd/config.toml" ]; then
 		mkdir -p "/home/${LIMA_CIDATA_USER}.linux/.config/containerd"
 		cat >"/home/${LIMA_CIDATA_USER}.linux/.config/containerd/config.toml" <<EOF


### PR DESCRIPTION
Unfortunately I couldn't find a corresponding image for aarch64.

Also containerd still failing:

```console
jan@lima-opensuse:/Users/jan> nerdctl pull ghcr.io/stargz-containers/nginx:1.19-alpine-org
ghcr.io/stargz-containers/nginx:1.19-alpine-org:                                  resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:d942e5263869b00ed3174fb76573165dc89e391bfafa43e9134a9c6e0bf0ec87:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:4fe11ac2b8ee14157911dd2029b6e30b7aed3888f4549e733aa51930a4af52af: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:72ab4137bd85aae7970407cbf4ba98ec0a7cb9d302e93a38bb665ba5fddf6f5d:   downloading    |--------------------------------------|    0.0 B/8.0 KiB
elapsed: 1.0 s                                                                    total:  3.1 Ki (3.1 KiB/s)
FATA[0001] failed to prepare extraction snapshot "extract-934522752-ByGC sha256:8ea3b23f387bedc5e3cee574742d748941443c328a75f511eb37b0d8b6164130": connection error: desc = "transport: Error while dialing dial unix:///run/user/501/containerd-fuse-overlayfs.sock: timeout": unavailable
```