### PR TITLE
Add copy/cp/scp command

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+
+	"github.com/AkihiroSuda/lima/pkg/sshutil"
+	"github.com/AkihiroSuda/lima/pkg/store"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+var copyCommand = &cli.Command{
+	Name:        "copy",
+	Aliases:     []string{"cp"},
+	Usage:       "Copy files between host and guest",
+	Description: "Prefix guest filenames with the instance name and a colon.\nExample: limactl copy default:/etc/os-release .",
+	ArgsUsage:   "SOURCE ... TARGET",
+	Action:      copyAction,
+}
+
+func copyAction(clicontext *cli.Context) error {
+	if clicontext.NArg() < 2 {
+		return errors.Errorf("requires at least 2 arguments: SOURCE DEST")
+	}
+	arg0, err := exec.LookPath("scp")
+	if err != nil {
+		return err
+	}
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	args, err := sshutil.CommonArgs()
+	if err != nil {
+		return err
+	}
+	args = append(args, "-3", "--")
+	for _, arg := range clicontext.Args().Slice() {
+		path := strings.Split(arg, ":")
+		switch len(path) {
+		case 1:
+			args = append(args, arg)
+		case 2:
+			instName := path[0]
+			inst, err := store.Inspect(instName)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return errors.Errorf("instance %q does not exist, run `limactl start %s` to create a new instance", instName, instName)
+				}
+				return err
+			}
+			if inst.Status == store.StatusStopped {
+				return errors.Errorf("instance %q is stopped, run `limactl start %s` to start the instance", instName, instName)
+			}
+			args = append(args, fmt.Sprintf("scp://%s@127.0.0.1:%d/%s", u.Username, inst.SSHLocalPort, path[1]))
+		default:
+			return errors.Errorf("Path %q contains multiple colons", arg)
+		}
+	}
+	cmd := exec.Command(arg0, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	logrus.Debugf("executing scp (may take a long)): %+v", cmd.Args)
+
+	// TODO: use syscall.Exec directly (results in losing tty?)
+	return cmd.Run()
+}

--- a/cmd/limactl/main.go
+++ b/cmd/limactl/main.go
@@ -44,6 +44,7 @@ func newApp() *cli.App {
 		startCommand,
 		stopCommand,
 		shellCommand,
+		copyCommand,
 		listCommand,
 		deleteCommand,
 		validateCommand,

--- a/hack/test-example.sh
+++ b/hack/test-example.sh
@@ -74,6 +74,19 @@ limactl shell "$NAME" uname -a
 limactl shell "$NAME" cat /etc/os-release
 set +x
 
+INFO "Testing limactl copy command"
+tmpfile="$HOME/lima-hostname"
+rm -f "$tmpfile"
+limactl cp "$NAME":/etc/hostname "$tmpfile"
+trap 'rm -f $tmpfile' EXIT
+expected="$(limactl shell "$NAME" cat /etc/hostname)"
+got="$(cat "$tmpfile")"
+INFO "/etc/hostname: expected=${expected}, got=${got}"
+if [ "$got" != "$expected" ]; then
+	ERROR "copy command did not fetch the file"
+	exit 1
+fi
+
 if [[ -n ${CHECKS["systemd"]} ]]; then
 	set -x
 	if ! limactl shell "$NAME" systemctl is-system-running --wait; then


### PR DESCRIPTION
This is a wrapper around `scp`. User doesn't have to lookup / specify the port number, and doesn't have to prefix remote names with `127.0.0.1:`; a single `:` is enough. And the connection goes through the ControlPath.

Example:

```
limactl cp default :/etc/os-release .
```