### PR TITLE
CI: add .cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,44 @@
+---
+# We use Cirrus for most of integration tests, because macOS instances of GHA
+# are too slow and flaky, and Linux instances of GHA do not support KVM.
+
+# yamllint disable rule:line-length
+task:
+  timeout_in: 30m
+  # We can't use macOS instances of Cirrus because of lack of support for nested VMs.
+  # (sysctl machdep.cpu.features lacks "VMX" flag)
+  container:
+    image: ubuntu:21.04
+    kvm: true
+    cpu: 2
+    memory: 8G
+  env:
+    DEBIAN_FRONTEND: noninteractive
+    # yamllint disable rule:key-duplicates
+    matrix:
+      # default.yaml is tested on GHA macOS, so we skip default.yaml here
+      EXAMPLE: alpine.yaml
+      EXAMPLE: debian.yaml
+      EXAMPLE: fedora.yaml
+      EXAMPLE: archlinux.yaml
+      EXAMPLE: opensuse.yaml
+  info_script:
+    - uname -a
+    - df -T
+    - ls -l /dev/kvm
+    - cat /proc/cpuinfo
+  install_deps_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends ca-certificates curl git golang openssh-client make ovmf sudo qemu-system-x86 qemu-utils
+  go_cache:
+    fingerprint_script: uname -s ; cat go.sum
+    folder: $GOPATH/pkg/mod
+  build_script: make
+  install_script: make install
+  prepare_user_script:
+    - groupadd -g $(stat -c '%g' /dev/kvm) kvm
+    - useradd -m -G kvm testuser
+  lima_cache:
+    fingerprint_script: uname -s ; cat examples/$EXAMPLE
+    folder: /home/testuser/.cache/lima
+  test_script: sudo -iu testuser $(pwd)/hack/test-example.sh $(pwd)/examples/$EXAMPLE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,9 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        example: [default.yaml, alpine.yaml, debian.yaml, fedora.yaml, archlinux.yaml, opensuse.yaml]
+        # GHA macOS is slow and flaky, so we only test "default.yaml" here.
+        # Other yamls are tested on Linux instances of Cirrus.
+        example: [default.yaml]
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Fix #94 


- - -

- `default.yaml` is still tested on macOS instances of GHA
- Other yamls are tested on Linux instances of Cirrus. macOS instances of Cirrus cannot be used due to lack of support for nested VMs.

Unlike GHA, Cirrus allows restarting an individual failed test.
![image](https://user-images.githubusercontent.com/9248427/123778204-d668eb80-d90b-11eb-9d68-345854367a00.png)
