### PR TITLE
Move /etc/ssh to persistent data-volume

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
@@ -7,7 +7,7 @@ set -eux -o pipefail
 test -f /etc/alpine-release || exit 0
 
 # Data directories that should be persisted across reboots
-DATADIRS="/home /usr/local /etc/containerd /var/lib/containerd"
+DATADIRS="/etc/ssh /home /usr/local /etc/containerd /var/lib/containerd"
 
 # When running from RAM try to move persistent data to data-volume
 # FIXME: the test for tmpfs mounts is probably Alpine-specific


### PR DESCRIPTION
Although lima doesn't store the host key, it is wrong to change it on every reboot.
