### PR TITLE
ssh: allow `ssh.loadDotSSHPubKeys = false`

### DIFF
--- a/cmd/limactl/copy.go
+++ b/cmd/limactl/copy.go
@@ -36,7 +36,8 @@ func copyAction(clicontext *cli.Context) error {
 		return err
 	}
 
-	args, err := sshutil.CommonArgs()
+	const useDotSSH = true
+	args, err := sshutil.CommonArgs(useDotSSH)
 	if err != nil {
 		return err
 	}

--- a/cmd/limactl/shell.go
+++ b/cmd/limactl/shell.go
@@ -103,7 +103,7 @@ func shellAction(clicontext *cli.Context) error {
 		return err
 	}
 
-	args, err := sshutil.SSHArgs(inst.Dir)
+	args, err := sshutil.SSHArgs(inst.Dir, *y.SSH.LoadDotSSHPubKeys)
 	if err != nil {
 		return err
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -41,7 +41,7 @@ func GenerateISO9660(isoPath, name string, y *limayaml.LimaYAML) error {
 		Containerd: Containerd{System: *y.Containerd.System, User: *y.Containerd.User},
 	}
 
-	pubKeys, err := sshutil.DefaultPubKeys()
+	pubKeys, err := sshutil.DefaultPubKeys(*y.SSH.LoadDotSSHPubKeys)
 	if err != nil {
 		return err
 	}

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -66,6 +66,7 @@ func New(instName string, stdout, stderr io.Writer, sigintCh chan os.Signal) (*H
 	if err != nil {
 		return nil, err
 	}
+	// y is loaded with FillDefault() already, so no need to care about nil pointers.
 
 	qCfg := qemu.Config{
 		Name:        instName,
@@ -77,7 +78,7 @@ func New(instName string, stdout, stderr io.Writer, sigintCh chan os.Signal) (*H
 		return nil, err
 	}
 
-	sshArgs, err := sshutil.SSHArgs(inst.Dir)
+	sshArgs, err := sshutil.SSHArgs(inst.Dir, *y.SSH.LoadDotSSHPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -46,6 +46,12 @@ ssh:
   # Currently, this port number has to be specified manually.
   # Default: none
   localPort: 60022
+  # Load ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
+  # This option is useful when you want to use other SSH-based
+  # applications such as rsync with the Lima instance.
+  # If you have an insecure key under ~/.ssh, do not use this option.
+  # Default: true
+  loadDotSSHPubKeys: true
 
 firmware:
   # Use legacy BIOS instead of UEFI.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -25,6 +25,9 @@ func FillDefault(y *LimaYAML) {
 	if y.Video.Display == "" {
 		y.Video.Display = "none"
 	}
+	if y.SSH.LoadDotSSHPubKeys == nil {
+		y.SSH.LoadDotSSHPubKeys = &[]bool{true}[0]
+	}
 	for i := range y.Provision {
 		provision := &y.Provision[i]
 		if provision.Mode == "" {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -34,6 +34,10 @@ type Mount struct {
 
 type SSH struct {
 	LocalPort int `yaml:"localPort,omitempty"` // REQUIRED (FIXME: auto assign)
+
+	// LoadDotSSHPubKeys loads ~/.ssh/*.pub in addition to $LIMA_HOME/_config/user.pub .
+	// Default: true
+	LoadDotSSHPubKeys *bool `yaml:"loadDotSSHPubKeys,omitempty"`
 }
 
 type Firmware struct {
@@ -60,8 +64,8 @@ type Provision struct {
 }
 
 type Containerd struct {
-	System *bool `yaml:"system,omitempty"`
-	User   *bool `yaml:"user,omitempty"`
+	System *bool `yaml:"system,omitempty"` // default: false
+	User   *bool `yaml:"user,omitempty"`   // default: true
 }
 
 type ProbeMode = string

--- a/pkg/sshutil/sshutil_test.go
+++ b/pkg/sshutil/sshutil_test.go
@@ -3,7 +3,7 @@ package sshutil
 import "testing"
 
 func TestDefaultPubKeys(t *testing.T) {
-	keys, _ := DefaultPubKeys()
+	keys, _ := DefaultPubKeys(true)
 	t.Logf("found %d public keys", len(keys))
 	for _, key := range keys {
 		t.Logf("%s: %q", key.Filename, key.Content)


### PR DESCRIPTION
`ssh.loadDotSSHPubKeys` (boolean) specifies whether to load `~/.ssh/*.pub` in addition to `$LIMA_HOME/_config/user`.

The default value remains true.

 - - -
I'll release v0.5.0 after merging this and https://github.com/AkihiroSuda/lima/pull/106
