### PR TITLE
Always disregard ~/.ssh/config; only use specified identity file

### DIFF
--- a/pkg/sshutil/sshutil.go
+++ b/pkg/sshutil/sshutil.go
@@ -160,6 +160,8 @@ func CommonArgs(useDotSSH bool) ([]string, error) {
 		"-o", "PreferredAuthentications=publickey",
 		"-o", "Compression=no",
 		"-o", "BatchMode=yes",
+		"-o", "IdentitiesOnly=yes",
+		"-F", "/dev/null",
 	)
 	return args, nil
 }


### PR DESCRIPTION
This change is from debugging a setup issue with lima 0.4.0 by @mook-as.

It was no longer required with 0.5.0, but it shouldn't hurt, and might be useful to avoid other conflicts.