### PR TITLE
Use bind mounts instead of symlinks to move directories to data volume

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
@@ -44,8 +44,8 @@ if [ "$(awk '$2 == "/" {print $3}' /proc/mounts)" == "tmpfs" ]; then
 	fi
 	for DIR in ${DATADIRS}; do
 		if [ -d /mnt/data"${DIR}" ]; then
-			[ -e "${DIR}" ] && rm -rf "${DIR}"
-			ln -s /mnt/data"${DIR}" "${DIR}"
+			mkdir -p "${DIR}"
+			mount --bind /mnt/data"${DIR}" "${DIR}"
 		fi
 	done
 fi


### PR DESCRIPTION
This makes the relocation more transparent to apps and users because symlinks are sometimes treated differently.

E.g.

```console
$ l shell alpine
lima-alpine:/Users/jan$ cd
lima-alpine:/mnt/data/home/jan.linux$
```

becomes

```console
$ l shell alpine
lima-alpine:/Users/jan$ cd
lima-alpine:~$
```