### PR TITLE
Allow forwarding of specified port ranges to all interfaces

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ task:
     - cat /proc/cpuinfo
   install_deps_script:
     - apt-get update
-    - apt-get install -y --no-install-recommends ca-certificates curl git golang openssh-client make ovmf sudo qemu-system-x86 qemu-utils
+    - apt-get install -y --no-install-recommends ca-certificates curl git golang openssh-client make netcat ovmf sudo qemu-system-x86 qemu-utils
   go_cache:
     fingerprint_script: uname -s ; cat go.sum
     folder: $GOPATH/pkg/mod

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -15,6 +15,7 @@
 use strict;
 use warnings;
 
+use Config qw(%Config);
 use IO::Handle qw();
 use Socket qw(inet_ntoa);
 use Sys::Hostname qw(hostname);
@@ -76,7 +77,10 @@ while (<DATA>) {
     /^(forward|ignore):\s+([0-9.:]+)\s+(\d+)(?:\s+→)?(?:\s+([0-9.:]+)(?:\s+(\d+))?)?/;
     die "Cannot parse test '$_'" unless $1;
     my %test; @test{qw(mode guest_ip guest_port host_ip host_port)} = ($1, $2, $3, $4, $5);
-
+    if ($test{mode} eq "forward" && $test{host_port} < 1024 && $Config{osname} ne "darwin") {
+        printf "🚧 Not supported on $Config{osname}: # $_\n";
+        next;
+    }
     $test{host_ip} ||= "127.0.0.1";
     $test{host_port} ||= $test{guest_port};
 

--- a/hack/test-port-forwarding.pl
+++ b/hack/test-port-forwarding.pl
@@ -1,0 +1,292 @@
+#!/usr/bin/env perl
+
+# This script tests the port forwarding settings of lima. It has to be run
+# twice: once to update the instance yaml file with the port forwarding
+# rules (before the instance is started). And once when the instance is
+# running to perform the tests:
+#
+# ./hack/test-port-forwarding.pl examples/default.yaml
+# limactl start --tty=false examples/default.yaml
+# git restore pkg/limayaml/default.yaml
+# ./hack/test-port-forwarding.pl default
+#
+# TODO: support for ipv6 host addresses
+
+use strict;
+use warnings;
+
+use IO::Handle qw();
+use Socket qw(inet_ntoa);
+use Sys::Hostname qw(hostname);
+
+my $instance = shift;
+
+my $ipv4 = inet_ntoa(scalar gethostbyname(hostname())) or die;
+my $ipv6 = ""; # todo
+
+# If $instance is a filename, add our portForwards to it to enable testing
+if (-f $instance) {
+    open(my $fh, "+< $instance") or die "Can't open $instance for read/write: $!";
+    my @yaml;
+    while (<$fh>) {
+        # Remove existing "portForwards:" section from the config file
+        my $seq = /^portForwards:/ ... /^[a-z]/;
+        next if $seq && $seq !~ /E0$/;
+        push @yaml, $_;
+    }
+    seek($fh, 0, 0);
+    truncate($fh, 0);
+    print $fh $_ for @yaml;
+    while (<DATA>) {
+        s/ipv4/$ipv4/g;
+        s/ipv6/$ipv6/g;
+        print $fh $_;
+    }
+    exit;
+}
+
+# Otherwise $instance must be the name of an already running instance that has been
+# configured with our portForwards settings.
+
+# Get sshLocalPort for lima instance
+my $sshLocalPort;
+open(my $ls, "limactl ls --json |") or die;
+while (<$ls>) {
+    next unless /"name":"$instance"/;
+    ($sshLocalPort) = /"sshLocalPort":(\d+)/ or die;
+    last;
+}
+die "Cannot determine sshLocalPort" unless $sshLocalPort;
+
+# Extract forwarding tests from the "portForwards" section
+my @test;
+while (<DATA>) {
+    chomp;
+    s/^\s+#\s*//;
+    next unless /^(forward|ignore)/;
+    if (/ipv6/ && !$ipv6) {
+        printf "🚧 Not yet: # $_\n";
+        next;
+    }
+    s/sshLocalPort/$sshLocalPort/g;
+    s/ipv4/$ipv4/g;
+    s/ipv6/$ipv6/g;
+    # forward: 127.0.0.1 899 → 127.0.0.1 799
+    # ignore: 127.0.0.2 8888
+    /^(forward|ignore):\s+([0-9.:]+)\s+(\d+)(?:\s+→)?(?:\s+([0-9.:]+)(?:\s+(\d+))?)?/;
+    die "Cannot parse test '$_'" unless $1;
+    my %test; @test{qw(mode guest_ip guest_port host_ip host_port)} = ($1, $2, $3, $4, $5);
+
+    $test{host_ip} ||= "127.0.0.1";
+    $test{host_port} ||= $test{guest_port};
+
+    my $remote = JoinHostPort($test{guest_ip},$test{guest_port});
+    my $local = JoinHostPort($test{host_ip},$test{host_port});
+    if ($test{mode} eq "ignore") {
+        $test{log_msg} = "Not forwarding TCP $remote";
+    }
+    else {
+        $test{log_msg} = "Forwarding TCP from $remote to $local";
+    }
+    push @test, \%test;
+}
+
+open(my $lima, "| limactl shell --workdir / $instance")
+  or die "Can't run lima shell on $instance: $!";
+$lima->autoflush;
+
+print $lima <<'EOF';
+set -e
+cd $HOME
+sudo pkill -x nc || true
+rm -f nc.*
+EOF
+
+# Give the hostagent some time to remove any port forwards from a previous (crashed?) test run
+sleep 5;
+
+# Record current log size, so we can skip prior output
+$ENV{LIMA_HOME} ||= "$ENV{HOME}/.lima";
+my $ha_log = "$ENV{LIMA_HOME}/$instance/ha.stderr.log";
+my $ha_log_size = -s $ha_log or die;
+
+# Setup a netcat listener on the guest for each test
+foreach my $id (0..@test-1) {
+    my $test = $test[$id];
+    my $nc = "nc -l $test->{guest_ip} $test->{guest_port}";
+    if ($instance eq "alpine") {
+        $nc = "nc -l -s $test->{guest_ip} -p $test->{guest_port}";
+    }
+
+    my $sudo = $test->{guest_port} < 1024 ? "sudo " : "";
+    print $lima "${sudo}${nc} >nc.${id} 2>/dev/null &\n";
+}
+
+# Make sure the guest- and hostagents had enough time to set up the forwards
+sleep 5;
+
+# Try to reach each listener from the host
+foreach my $test (@test) {
+    next if $test->{host_port} == $sshLocalPort;
+    my $nc = "nc -w 1 $test->{host_ip} $test->{host_port}";
+    open(my $netcat, "| $nc") or die "Can't run '$nc': $!";
+    print $netcat "$test->{log_msg}\n";
+    # Don't check for errors on close; macOS nc seems to return non-zero exit code even on success
+    close($netcat);
+}
+
+# Extract forwarding log messages from hostagent log
+open(my $log, "< $ha_log") or die "Can't read $ha_log: $!";
+seek($log, $ha_log_size, 0) or die "Can't seek $ha_log to $ha_log_size: $!";
+my %seen;
+while (<$log>) {
+    $seen{$1}++ if /(Forwarding TCP from .*? to (\d.*?|\[.*?\]):\d+)/;
+    $seen{$1}++ if /(Not forwarding TCP .*?:\d+)/;
+}
+close $log or die;
+
+my $rc = 0;
+my %expected;
+foreach my $id (0..@test-1) {
+    my $test = $test[$id];
+    my $err = "";
+    $expected{$test->{log_msg}}++;
+    unless ($seen{$test->{log_msg}}) {
+        $err .= "\n   Message missing from ha.stderr.log";
+    }
+    my $log = qx(limactl shell --workdir / $instance sh -c "cd; cat nc.$id");
+    chomp $log;
+    if ($test->{mode} eq "forward" && $test->{log_msg} ne $log) {
+        $err .= "\n   Guest received: '$log'";
+    }
+    if ($test->{mode} eq "ignore" && $log) {
+        $err .= "\n   Guest received: '$log' (instead of nothing)";
+    }
+    printf "%s %s%s\n", ($err ? "❌" : "✅"), $test->{log_msg}, $err;
+    $rc = 1 if $err;
+}
+
+foreach (keys %seen) {
+    next if $expected{$_};
+    # Should this be an error? Really should only happen if something else failed as well.
+    print "😕 Unexpected log message: $_\n";
+}
+
+# Cleanup remaining netcat instances (and port forwards)
+print $lima "sudo pkill -x nc";
+
+exit $rc;
+
+sub JoinHostPort {
+    my($host,$port) = @_;
+    $host = "[$host]" if $host =~ /:/;
+    return "$host:$port";
+}
+
+# This YAML section includes port forwarding `rules` for the guest- and hostagents,
+# with interleaved `tests` (in comments) that are executed by this script. The strings
+# "ipv4" and "ipv6" will be replaced by the actual host ipv4 and ipv6 addresses.
+__DATA__
+portForwards:
+  # We can't test that port 22 will be blocked because the guestagent has
+  # been ignoring it since startup, so the log message is in the part of
+  # the log we skipped.
+  # skip: 127.0.0.1 22 → 127.0.0.1 2222
+  # ignore: 127.0.0.1 sshLocalPort
+
+- guestIP: 127.0.0.2
+  guestPortRange: [3000, 3009]
+  hostPortRange: [2000, 2009]
+  ignore: true
+
+- guestIP: 0.0.0.0
+  guestPortRange: [3010, 3019]
+  hostPortRange: [2010, 2019]
+  ignore: true
+
+- guestIP: 0.0.0.0
+  guestPortRange: [3000, 3029]
+  hostPortRange: [2000, 2029]
+
+# The following rule is completely shadowed by the previous one and has no effect
+- guestIP: 0.0.0.0
+  guestPortRange: [3020, 3029]
+  hostPortRange: [2020, 2029]
+  ignore: true
+
+  # ignore:  127.0.0.2 3000
+  # forward: 127.0.0.3 3001 → 127.0.0.1 2001
+
+  # Blocking 127.0.0.2 cannot block forwarding from 0.0.0.0
+  # forward: 0.0.0.0   3002 → 127.0.0.1 2002
+
+  # Blocking 0.0.0.0 will block forwarding from any interface
+  # ignore: 0.0.0.0   3010
+  # ignore: 127.0.0.1 3011
+
+  # Forwarding from 0.0.0.0 works for any interface (including IPv6)
+  # The "ignore" rule above has no effect because the previous rule already matched.
+  # forward: 127.0.0.2 3020 → 127.0.0.1 2020
+  # forward: 127.0.0.1 3021 → 127.0.0.1 2021
+  # forward: 0.0.0.0   3022 → 127.0.0.1 2022
+  # forward: ::        3023 → 127.0.0.1 2023
+  # forward: ::1       3024 → 127.0.0.1 2024
+
+- guestPortRange: [3030, 3039]
+  hostPortRange: [2030, 2039]
+  hostIP: ipv4
+
+  # forward: 127.0.0.1 3030 → ipv4 2030
+  # forward: 0.0.0.0   3031 → ipv4 2031
+  # forward: ::        3032 → ipv4 2032
+  # forward: ::1       3033 → ipv4 2033
+
+# Forwarding privileged ports to 127.0.0.1 does not work yet
+- guestPortRange: [300, 309]
+
+  # Hostagent will try to setup forward, but ssh will fail to bind to port
+  # skip: 127.0.0.1 300 → 127.0.0.1 300
+
+- guestPortRange: [310, 319]
+  hostIP: 0.0.0.0
+
+  # forward: 127.0.0.1 310 → 0.0.0.0 310
+
+  # Things we can't test:
+  # - Accessing a forward from a different interface (e.g. connect to ipv4 to connect to 0.0.0.0)
+  # - failed forward to privileged port
+
+
+- guestIP: "192.168.5.15"
+  guestPortRange: [4000, 4009]
+  hostIP: "ipv4"
+
+  # forward: 192.168.5.15 4000 → ipv4 4000
+
+- guestIP: "::1"
+  guestPortRange: [4010, 4019]
+  hostIP: "::"
+
+  # forward: ::1 4010 → :: 4010
+
+- guestIP: "::"
+  guestPortRange: [4020, 4029]
+  hostIP: "ipv4"
+
+  # forward: 127.0.0.1    4020 → ipv4 4020
+  # forward: 127.0.0.2    4021 → ipv4 4021
+  # forward: 192.168.5.15 4022 → ipv4 4022
+  # forward: 0.0.0.0      4023 → ipv4 4023
+  # forward: ::           4024 → ipv4 4024
+  # forward: ::1          4025 → ipv4 4025
+
+- guestIP: "0.0.0.0"
+  guestPortRange: [4030, 4039]
+  hostIP: "ipv4"
+
+  # forward: 127.0.0.1    4030 → ipv4 4030
+  # forward: 127.0.0.2    4031 → ipv4 4031
+  # forward: 192.168.5.15 4032 → ipv4 4032
+  # forward: 0.0.0.0      4033 → ipv4 4033
+  # forward: ::           4034 → ipv4 4034
+  # forward: ::1          4035 → ipv4 4035

--- a/pkg/guestagent/api/api.go
+++ b/pkg/guestagent/api/api.go
@@ -11,6 +11,10 @@ type ErrorJSON struct {
 	Message string `json:"message"`
 }
 
+var (
+	IPv4loopback1 = net.IPv4(127,0,0,1)
+)
+
 type IPPort struct {
 	IP   net.IP `json:"ip"`
 	Port int    `json:"port"`

--- a/pkg/guestagent/guestagent_linux.go
+++ b/pkg/guestagent/guestagent_linux.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"net"
 	"reflect"
 	"time"
 
@@ -116,18 +115,13 @@ func (a *agent) LocalPorts(ctx context.Context) ([]api.IPPort, error) {
 		return res, err
 	}
 
-	ipv4Loopback1 := net.ParseIP("127.0.0.1")
 	for _, f := range tcpParsed {
 		switch f.Kind {
 		case procnettcp.TCP, procnettcp.TCP6:
 		default:
 			continue
 		}
-		isListen := f.State == procnettcp.TCPListen
-		// We do NOT use net.IP.IsLoopback() here, because we want to exclude addresses like 127.0.0.53 here.
-		isLocal := f.IP.Equal(net.IPv4zero) || f.IP.Equal(net.IPv6zero) ||
-			f.IP.Equal(ipv4Loopback1) || f.IP.Equal(net.IPv6loopback)
-		if isListen && isLocal {
+		if f.State == procnettcp.TCPListen {
 			res = append(res,
 				api.IPPort{
 					IP:   f.IP,

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -91,7 +91,7 @@ func New(instName string, stdout, stderr io.Writer, sigintCh chan os.Signal) (*H
 		y:             y,
 		instDir:       inst.Dir,
 		sshConfig:     sshConfig,
-		portForwarder: newPortForwarder(l, sshConfig, y.SSH.LocalPort),
+		portForwarder: newPortForwarder(l, sshConfig, y.SSH.LocalPort, y.Ports),
 		qExe:          qExe,
 		qArgs:         qArgs,
 		sigintCh:      sigintCh,

--- a/pkg/hostagent/hostagent.go
+++ b/pkg/hostagent/hostagent.go
@@ -86,12 +86,17 @@ func New(instName string, stdout, stderr io.Writer, sigintCh chan os.Signal) (*H
 		AdditionalArgs: sshArgs,
 	}
 
+	ports := make([]limayaml.Port, 0, 2+len(y.Ports))
+	ports = append(ports, limayaml.Port{GuestPort: sshGuestPort, Ignore: true})
+	ports = append(ports, limayaml.Port{GuestPort: y.SSH.LocalPort, Ignore: true})
+	ports = append(ports, y.Ports...)
+
 	a := &HostAgent{
 		l:             l,
 		y:             y,
 		instDir:       inst.Dir,
 		sshConfig:     sshConfig,
-		portForwarder: newPortForwarder(l, sshConfig, y.SSH.LocalPort, y.Ports),
+		portForwarder: newPortForwarder(l, sshConfig, y.SSH.LocalPort, ports),
 		qExe:          qExe,
 		qArgs:         qArgs,
 		sigintCh:      sigintCh,

--- a/pkg/hostagent/port.go
+++ b/pkg/hostagent/port.go
@@ -2,8 +2,7 @@ package hostagent
 
 import (
 	"context"
-	"fmt"
-	"strconv"
+	"net"
 
 	"github.com/AkihiroSuda/lima/pkg/guestagent/api"
 	"github.com/AkihiroSuda/lima/pkg/limayaml"
@@ -16,48 +15,60 @@ type portForwarder struct {
 	sshConfig   *ssh.SSHConfig
 	sshHostPort int
 	tcp         map[int]struct{} // key: int (NOTE: this might be inconsistent with the actual status of SSH master)
-	ports       []limayaml.Port
+	rules       []limayaml.PortForward
 }
 
 const sshGuestPort = 22
 
-func newPortForwarder(l *logrus.Logger, sshConfig *ssh.SSHConfig, sshHostPort int, ports []limayaml.Port) *portForwarder {
+func newPortForwarder(l *logrus.Logger, sshConfig *ssh.SSHConfig, sshHostPort int, rules []limayaml.PortForward) *portForwarder {
 	return &portForwarder{
 		l:           l,
 		sshConfig:   sshConfig,
 		sshHostPort: sshHostPort,
 		tcp:         make(map[int]struct{}),
-		ports:       ports,
+		rules:       rules,
 	}
 }
 
 func (pf *portForwarder) forwardingAddresses(guest api.IPPort) (string, string) {
-	for _, port := range pf.ports {
-		if port.GuestPortRange[0] <= guest.Port && guest.Port <= port.GuestPortRange[1] {
-			guestAddr := fmt.Sprintf("%s:%d", port.GuestIP, guest.Port)
-			if port.Ignore {
-				return guestAddr, ""
-			}
-			offset := port.HostPortRange[0] - port.GuestPortRange[0]
-			hostAddr := fmt.Sprintf("%s:%d", port.HostIP, guest.Port + offset)
-			return guestAddr, hostAddr
+	for _, rule := range pf.rules {
+		if guest.Port < rule.GuestPortRange[0] || guest.Port > rule.GuestPortRange[1] {
+			continue
 		}
+		switch {
+		case guest.IP.IsUnspecified():
+		case guest.IP.Equal(rule.GuestIP):
+		case guest.IP.Equal(net.IPv6loopback) && rule.GuestIP.Equal(api.IPv4loopback1):
+		case rule.GuestIP.IsUnspecified():
+		default:
+			continue
+		}
+		if rule.Ignore {
+			if guest.IP.IsUnspecified() && !rule.GuestIP.IsUnspecified() {
+				continue
+			}
+			break
+		}
+		host := api.IPPort{
+			IP:   rule.HostIP,
+			Port: guest.Port + rule.HostPortRange[0] - rule.GuestPortRange[0],
+		}
+		return host.String(), guest.String()
 	}
-	addr := "127.0.0.1:" + strconv.Itoa(guest.Port)
-	return addr, addr
+	return "", guest.String()
 }
 
 func (pf *portForwarder) OnEvent(ctx context.Context, ev api.Event) {
 	for _, f := range ev.LocalPortsRemoved {
 		// pf.tcp might be inconsistent with the actual state of the SSH master,
 		// so we always attempt to cancel forwarding, even when f.Port is not tracked in pf.tcp.
-		guestAddr, hostAddr := pf.forwardingAddresses(f)
-		if hostAddr == "" {
+		local, remote := pf.forwardingAddresses(f)
+		if local == "" {
 			continue
 		}
-		pf.l.Infof("Stopping forwarding TCP from %s to %s", guestAddr, hostAddr)
+		pf.l.Infof("Stopping forwarding TCP from %s to %s", remote, local)
 		verbCancel := true
-		if err := forwardSSH(ctx, pf.sshConfig, pf.sshHostPort, hostAddr, guestAddr, verbCancel); err != nil {
+		if err := forwardSSH(ctx, pf.sshConfig, pf.sshHostPort, local, remote, verbCancel); err != nil {
 			if _, ok := pf.tcp[f.Port]; ok {
 				pf.l.WithError(err).Warnf("failed to stop forwarding TCP port %d", f.Port)
 			} else {
@@ -67,14 +78,14 @@ func (pf *portForwarder) OnEvent(ctx context.Context, ev api.Event) {
 		delete(pf.tcp, f.Port)
 	}
 	for _, f := range ev.LocalPortsAdded {
-		guestAddr, hostAddr := pf.forwardingAddresses(f)
-		if hostAddr == "" {
-			pf.l.Infof("Not forwarding TCP from %s", guestAddr)
+		local, remote := pf.forwardingAddresses(f)
+		if local == "" {
+			pf.l.Infof("Not forwarding TCP %s", remote)
 			continue
 		}
-		pf.l.Infof("Forwarding TCP from %s to %s", guestAddr, hostAddr)
-		if err := forwardSSH(ctx, pf.sshConfig, pf.sshHostPort, hostAddr, guestAddr, false); err != nil {
-			pf.l.WithError(err).Warnf("failed to setting up forward TCP port %d (negligible if already forwarded)", f.Port)
+		pf.l.Infof("Forwarding TCP from %s to %s", remote, local)
+		if err := forwardSSH(ctx, pf.sshConfig, pf.sshHostPort, local, remote, false); err != nil {
+			pf.l.WithError(err).Warnf("failed to set up forwarding TCP port %d (negligible if already forwarded)", f.Port)
 		} else {
 			pf.tcp[f.Port] = struct{}{}
 		}

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -73,6 +73,24 @@ containerd:
   # Default: true
   user: true
 
+# port forwarding rules.
+# By default guest ports are forwarded to the same port on the 127.0.0.1 interface on the host.
+# ports:
+
+#   - guestPort: 443
+#     hostIP: "0.0.0.0" # overrides the default value "127.0.0.1"
+#   # default: hostPort: 443
+#   # default: guestIP: "127.0.0.1" (only valid value right now)
+#   # default: proto: "tcp" (only valid value right now)
+
+#   - guestPortRange: [4000, 4999]
+#     hostIP:  "0.0.0.0" # overrides the default value "127.0.0.1"
+#   # default: hostPortRange: [4000, 4999] (must specify same number of ports as guestPortRange)
+
+#   - guestPort: 80
+#     hostPort: 8080 # overrides the default value 80
+
+
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.
 # provision:

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -90,6 +90,8 @@ containerd:
 #   - guestPort: 80
 #     hostPort: 8080 # overrides the default value 80
 
+#   - guestPort: 8888
+#     ignore: true (don't forward this port)
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.

--- a/pkg/limayaml/default.yaml
+++ b/pkg/limayaml/default.yaml
@@ -73,25 +73,31 @@ containerd:
   # Default: true
   user: true
 
-# port forwarding rules.
-# By default guest ports are forwarded to the same port on the 127.0.0.1 interface on the host.
-# ports:
-
+# Port forwarding rules. Forwarding between ports 22 and ssh.localPort cannot be overridden.
+# Rules are checked sequentially until the first one matches.
+# portForwards:
 #   - guestPort: 443
-#     hostIP: "0.0.0.0" # overrides the default value "127.0.0.1"
-#   # default: hostPort: 443
-#   # default: guestIP: "127.0.0.1" (only valid value right now)
+#     hostIP: "0.0.0.0" # overrides the default value "127.0.0.1"; allows privileged port forwarding
+#   # default: hostPort: 443 (same as guestPort)
+#   # default: guestIP: "127.0.0.1" (also matches bind addresses "0.0.0.0", "::", and "::1")
 #   # default: proto: "tcp" (only valid value right now)
-
 #   - guestPortRange: [4000, 4999]
 #     hostIP:  "0.0.0.0" # overrides the default value "127.0.0.1"
 #   # default: hostPortRange: [4000, 4999] (must specify same number of ports as guestPortRange)
-
 #   - guestPort: 80
 #     hostPort: 8080 # overrides the default value 80
-
+#   - guestIP: "127.0.0.2" # overrides the default value "127.0.0.1"
+#     hostIP: "127.0.0.2" # overrides the default value "127.0.0.1"
+#   # default: guestPortRange: [1024, 65535]
+#   # default: hostPortRange: [1024, 65535]
 #   - guestPort: 8888
 #     ignore: true (don't forward this port)
+#   # Lima internally appends this fallback rule at the end:
+#   - guestIP: "127.0.0.1"
+#     guestPortRange: [1024, 65535]
+#     hostIP: "127.0.0.1"
+#     hostPortRange: [1024, 65535]
+#   # Any port still not matched by a rule will not be forwarded (ignored)
 
 # Provisioning scripts need to be idempotent because they might be called
 # multiple times, e.g. when the host VM is being restarted.

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -3,6 +3,8 @@ package limayaml
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/AkihiroSuda/lima/pkg/guestagent/api"
 )
 
 func FillDefault(y *LimaYAML) {
@@ -49,27 +51,37 @@ func FillDefault(y *LimaYAML) {
 			probe.Description = fmt.Sprintf("user probe %d/%d", i+1, len(y.Probes))
 		}
 	}
-	for i := range y.Ports {
-		port := &y.Ports[i]
-		if port.GuestIP == "" {
-			port.GuestIP = "127.0.0.1"
+	for i := range y.PortForwards {
+		FillPortForwardDefaults(&y.PortForwards[i])
+		// After defaults processing the singular HostPort and GuestPort values should not be used again.
+	}
+}
+
+func FillPortForwardDefaults(rule *PortForward) {
+	if rule.Proto == "" {
+		rule.Proto = TCP
+	}
+	if rule.GuestIP == nil {
+		rule.GuestIP = api.IPv4loopback1
+	}
+	if rule.HostIP == nil {
+		rule.HostIP = api.IPv4loopback1
+	}
+	if rule.GuestPortRange[0] == 0 && rule.GuestPortRange[1] == 0 {
+		if rule.GuestPort == 0 {
+			rule.GuestPortRange[0] = 1024
+			rule.GuestPortRange[1] = 65535
+		} else {
+			rule.GuestPortRange[0] = rule.GuestPort
+			rule.GuestPortRange[1] = rule.GuestPort
 		}
-		if port.GuestPortRange[0] == 0 && port.GuestPortRange[1] == 0 {
-			port.GuestPortRange[0] = port.GuestPort
-			port.GuestPortRange[1] = port.GuestPort
-		}
-		if port.HostIP == "" {
-			port.HostIP = "127.0.0.1"
-		}
-		if port.HostPortRange[0] == 0 && port.HostPortRange[1] == 0 {
-			if port.HostPort == 0 {
-				port.HostPort = port.GuestPortRange[0]
-			}
-			port.HostPortRange[0] = port.HostPort
-			port.HostPortRange[1] = port.HostPort
-		}
-		if port.Proto == "" {
-			port.Proto = TCP
+	}
+	if rule.HostPortRange[0] == 0 && rule.HostPortRange[1] == 0 {
+		if rule.HostPort == 0 {
+			rule.HostPortRange = rule.GuestPortRange
+		} else {
+			rule.HostPortRange[0] = rule.HostPort
+			rule.HostPortRange[1] = rule.HostPort
 		}
 	}
 }

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -49,6 +49,29 @@ func FillDefault(y *LimaYAML) {
 			probe.Description = fmt.Sprintf("user probe %d/%d", i+1, len(y.Probes))
 		}
 	}
+	for i := range y.Ports {
+		port := &y.Ports[i]
+		if port.GuestIP == "" {
+			port.GuestIP = "127.0.0.1"
+		}
+		if port.GuestPortRange[0] == 0 && port.GuestPortRange[1] == 0 {
+			port.GuestPortRange[0] = port.GuestPort
+			port.GuestPortRange[1] = port.GuestPort
+		}
+		if port.HostIP == "" {
+			port.HostIP = "127.0.0.1"
+		}
+		if port.HostPortRange[0] == 0 && port.HostPortRange[1] == 0 {
+			if port.HostPort == 0 {
+				port.HostPort = port.GuestPortRange[0]
+			}
+			port.HostPortRange[0] = port.HostPort
+			port.HostPortRange[1] = port.HostPort
+		}
+		if port.Proto == "" {
+			port.Proto = TCP
+		}
+	}
 }
 
 func resolveArch(s string) Arch {

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -15,6 +15,7 @@ type LimaYAML struct {
 	Provision  []Provision `yaml:"provision,omitempty"`
 	Containerd Containerd  `yaml:"containerd,omitempty"`
 	Probes     []Probe     `yaml:"probes,omitempty"`
+	Ports      []Port      `yaml:"ports,omitempty"`
 }
 
 type Arch = string
@@ -82,4 +83,20 @@ type Probe struct {
 	Description string
 	Script      string
 	Hint        string
+}
+
+type Proto = string
+
+const (
+	TCP Proto = "tcp"
+)
+
+type Port struct {
+	GuestIP        string `yaml:"guestIP,omitempty"`
+	GuestPort      int    `yaml:"guestPort,omitempty"`
+	GuestPortRange [2]int `yaml:"guestPortRange,omitempty"`
+	HostIP         string `yaml:"hostIP,omitempty"`
+	HostPort       int    `yaml:"hostPort,omitempty"`
+	HostPortRange  [2]int `yaml:"hostPortRange,omitempty"`
+	Proto          Proto  `yaml:"proto,omitempty"`
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -99,4 +99,5 @@ type Port struct {
 	HostPort       int    `yaml:"hostPort,omitempty"`
 	HostPortRange  [2]int `yaml:"hostPortRange,omitempty"`
 	Proto          Proto  `yaml:"proto,omitempty"`
+	Ignore         bool   `yaml:"ignore,omitempty"`
 }

--- a/pkg/limayaml/limayaml.go
+++ b/pkg/limayaml/limayaml.go
@@ -1,21 +1,25 @@
 package limayaml
 
-import "github.com/opencontainers/go-digest"
+import (
+	"net"
+
+	"github.com/opencontainers/go-digest"
+)
 
 type LimaYAML struct {
-	Arch       Arch        `yaml:"arch,omitempty"`
-	Images     []File      `yaml:"images"` // REQUIRED
-	CPUs       int         `yaml:"cpus,omitempty"`
-	Memory     string      `yaml:"memory,omitempty"` // go-units.RAMInBytes
-	Disk       string      `yaml:"disk,omitempty"`   // go-units.RAMInBytes
-	Mounts     []Mount     `yaml:"mounts,omitempty"`
-	SSH        SSH         `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
-	Firmware   Firmware    `yaml:"firmware,omitempty"`
-	Video      Video       `yaml:"video,omitempty"`
-	Provision  []Provision `yaml:"provision,omitempty"`
-	Containerd Containerd  `yaml:"containerd,omitempty"`
-	Probes     []Probe     `yaml:"probes,omitempty"`
-	Ports      []Port      `yaml:"ports,omitempty"`
+	Arch         Arch          `yaml:"arch,omitempty"`
+	Images       []File        `yaml:"images"` // REQUIRED
+	CPUs         int           `yaml:"cpus,omitempty"`
+	Memory       string        `yaml:"memory,omitempty"` // go-units.RAMInBytes
+	Disk         string        `yaml:"disk,omitempty"`   // go-units.RAMInBytes
+	Mounts       []Mount       `yaml:"mounts,omitempty"`
+	SSH          SSH           `yaml:"ssh,omitempty"` // REQUIRED (FIXME)
+	Firmware     Firmware      `yaml:"firmware,omitempty"`
+	Video        Video         `yaml:"video,omitempty"`
+	Provision    []Provision   `yaml:"provision,omitempty"`
+	Containerd   Containerd    `yaml:"containerd,omitempty"`
+	Probes       []Probe       `yaml:"probes,omitempty"`
+	PortForwards []PortForward `yaml:"portForwards,omitempty"`
 }
 
 type Arch = string
@@ -91,11 +95,11 @@ const (
 	TCP Proto = "tcp"
 )
 
-type Port struct {
-	GuestIP        string `yaml:"guestIP,omitempty"`
+type PortForward struct {
+	GuestIP        net.IP `yaml:"guestIP,omitempty"`
 	GuestPort      int    `yaml:"guestPort,omitempty"`
 	GuestPortRange [2]int `yaml:"guestPortRange,omitempty"`
-	HostIP         string `yaml:"hostIP,omitempty"`
+	HostIP         net.IP `yaml:"hostIP,omitempty"`
 	HostPort       int    `yaml:"hostPort,omitempty"`
 	HostPortRange  [2]int `yaml:"hostPortRange,omitempty"`
 	Proto          Proto  `yaml:"proto,omitempty"`

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -120,50 +120,44 @@ func ValidateRaw(y LimaYAML) error {
 				i, ProbeModeReadiness)
 		}
 	}
-	for i, port := range y.Ports {
-		field := fmt.Sprintf("ports[%d]", i)
-		if port.GuestIP != "127.0.0.1" {
-			return errors.Errorf("field `%s.guestIP` must be \"127.0.0.1\"", field)
-		}
-		if port.HostIP != "127.0.0.1" && port.HostIP != "0.0.0.0" {
-			return errors.Errorf("field `%s.hostIP` must be either \"127.0.0.1\" or \"0.0.0.0\"", field)
-		}
-		if port.GuestPort != 0 {
-			if port.GuestPort != port.GuestPortRange[0] {
+	for i, rule := range y.PortForwards {
+		field := fmt.Sprintf("portForwards[%d]", i)
+		if rule.GuestPort != 0 {
+			if rule.GuestPort != rule.GuestPortRange[0] {
 				return errors.Errorf("field `%s.guestPort` must match field `%s.guestPortRange[0]`", field, field)
 			}
 			// redundant validation to make sure the error contains the correct field name
-			if err := validatePort(field+".guestPort", port.GuestPort); err != nil {
+			if err := validatePort(field+".guestPort", rule.GuestPort); err != nil {
 				return err
 			}
 		}
-		if port.HostPort != 0 {
-			if port.HostPort != port.HostPortRange[0] {
+		if rule.HostPort != 0 {
+			if rule.HostPort != rule.HostPortRange[0] {
 				return errors.Errorf("field `%s.hostPort` must match field `%s.hostPortRange[0]`", field, field)
 			}
 			// redundant validation to make sure the error contains the correct field name
-			if err := validatePort(field+".hostPort", port.HostPort); err != nil {
+			if err := validatePort(field+".hostPort", rule.HostPort); err != nil {
 				return err
 			}
 		}
 		for j := 0; j < 2; j++ {
-			if err := validatePort(fmt.Sprintf("%s.guestPortRange[%d]", field, j), port.GuestPortRange[j]); err != nil {
+			if err := validatePort(fmt.Sprintf("%s.guestPortRange[%d]", field, j), rule.GuestPortRange[j]); err != nil {
 				return err
 			}
-			if err := validatePort(fmt.Sprintf("%s.hostPortRange[%d]", field, j), port.HostPortRange[j]); err != nil {
+			if err := validatePort(fmt.Sprintf("%s.hostPortRange[%d]", field, j), rule.HostPortRange[j]); err != nil {
 				return err
 			}
 		}
-		if port.GuestPortRange[0] > port.GuestPortRange[1] {
+		if rule.GuestPortRange[0] > rule.GuestPortRange[1] {
 			return errors.Errorf("field `%s.guestPortRange[1]` must be greater than or equal to field `%s.guestPortRange[0]`", field, field)
 		}
-		if port.HostPortRange[0] > port.HostPortRange[1] {
+		if rule.HostPortRange[0] > rule.HostPortRange[1] {
 			return errors.Errorf("field `%s.hostPortRange[1]` must be greater than or equal to field `%s.hostPortRange[0]`", field, field)
 		}
-		if port.GuestPortRange[1] - port.GuestPortRange[0] != port.HostPortRange[1] - port.HostPortRange[0] {
+		if rule.GuestPortRange[1] - rule.GuestPortRange[0] != rule.HostPortRange[1] - rule.HostPortRange[0] {
 			return errors.Errorf("field `%s.hostPortRange` must specify the same number of ports as field `%s.guestPortRange`", field, field)
 		}
-		if port.Proto != TCP {
+		if rule.Proto != TCP {
 			return errors.Errorf("field `%s.proto` must be %q", field, TCP)
 		}
 		// Not validating that the various GuestPortRanges and HostPortRanges are not overlapping. Rules will be

--- a/pkg/limayaml/validate.go
+++ b/pkg/limayaml/validate.go
@@ -98,15 +98,8 @@ func ValidateRaw(y LimaYAML) error {
 		}
 	}
 
-	switch {
-	case y.SSH.LocalPort < 0:
-		return errors.New("field `ssh.localPort` must be > 0")
-	case y.SSH.LocalPort == 0:
-		return errors.New("field `ssh.localPort` must be set, e.g, 60022 (FIXME: support automatic port assignment)")
-	case y.SSH.LocalPort == 22:
-		return errors.New("field `ssh.localPort` must not be 22")
-	case y.SSH.LocalPort > 65535:
-		return errors.New("field `ssh.localPort` must be < 65535")
+	if err := validatePort("ssh.localPort", y.SSH.LocalPort); err != nil {
+		return err
 	}
 
 	// y.Firmware.LegacyBIOS is ignored for aarch64, but not a fatal error.
@@ -126,6 +119,69 @@ func ValidateRaw(y LimaYAML) error {
 			return errors.Errorf("field `probe[%d].mode` can only be %q",
 				i, ProbeModeReadiness)
 		}
+	}
+	for i, port := range y.Ports {
+		field := fmt.Sprintf("ports[%d]", i)
+		if port.GuestIP != "127.0.0.1" {
+			return errors.Errorf("field `%s.guestIP` must be \"127.0.0.1\"", field)
+		}
+		if port.HostIP != "127.0.0.1" && port.HostIP != "0.0.0.0" {
+			return errors.Errorf("field `%s.hostIP` must be either \"127.0.0.1\" or \"0.0.0.0\"", field)
+		}
+		if port.GuestPort != 0 {
+			if port.GuestPort != port.GuestPortRange[0] {
+				return errors.Errorf("field `%s.guestPort` must match field `%s.guestPortRange[0]`", field, field)
+			}
+			// redundant validation to make sure the error contains the correct field name
+			if err := validatePort(field+".guestPort", port.GuestPort); err != nil {
+				return err
+			}
+		}
+		if port.HostPort != 0 {
+			if port.HostPort != port.HostPortRange[0] {
+				return errors.Errorf("field `%s.hostPort` must match field `%s.hostPortRange[0]`", field, field)
+			}
+			// redundant validation to make sure the error contains the correct field name
+			if err := validatePort(field+".hostPort", port.HostPort); err != nil {
+				return err
+			}
+		}
+		for j := 0; j < 2; j++ {
+			if err := validatePort(fmt.Sprintf("%s.guestPortRange[%d]", field, j), port.GuestPortRange[j]); err != nil {
+				return err
+			}
+			if err := validatePort(fmt.Sprintf("%s.hostPortRange[%d]", field, j), port.HostPortRange[j]); err != nil {
+				return err
+			}
+		}
+		if port.GuestPortRange[0] > port.GuestPortRange[1] {
+			return errors.Errorf("field `%s.guestPortRange[1]` must be greater than or equal to field `%s.guestPortRange[0]`", field, field)
+		}
+		if port.HostPortRange[0] > port.HostPortRange[1] {
+			return errors.Errorf("field `%s.hostPortRange[1]` must be greater than or equal to field `%s.hostPortRange[0]`", field, field)
+		}
+		if port.GuestPortRange[1] - port.GuestPortRange[0] != port.HostPortRange[1] - port.HostPortRange[0] {
+			return errors.Errorf("field `%s.hostPortRange` must specify the same number of ports as field `%s.guestPortRange`", field, field)
+		}
+		if port.Proto != TCP {
+			return errors.Errorf("field `%s.proto` must be %q", field, TCP)
+		}
+		// Not validating that the various GuestPortRanges and HostPortRanges are not overlapping. Rules will be
+		// processed sequentially and the first matching rule for a guest port determines forwarding behavior.
+	}
+	return nil
+}
+
+func validatePort(field string, port int) error {
+	switch {
+	case port < 0:
+		return errors.Errorf("field `%s` must be > 0", field)
+	case port == 0:
+		return errors.Errorf("field `%s` must be set", field)
+	case port == 22:
+		return errors.Errorf("field `%s` must not be 22", field)
+	case port > 65535:
+		return errors.Errorf("field `%s` must be < 65536", field)
 	}
 	return nil
 }


### PR DESCRIPTION
This allows to expose e.g. an ingress port outside of the local host while still forwarding other ports only to localhost.

Example:

```yaml
allInterfaces:
- port: 443
- port: 4000
  until: 4999
```

I'm not quite sure how this will interact with #45, but I think/hope it will be independent (the filtering of incoming connections would be done via `iptables` inside the guest?).

I'm also not really happy about the `allInterfaces` key name, but couldn't come up with anything better.