### PR TITLE
Move all of `/var/lib` to the persistent data volume

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
@@ -7,7 +7,7 @@ set -eux -o pipefail
 test -f /etc/alpine-release || exit 0
 
 # Data directories that should be persisted across reboots
-DATADIRS="/etc/ssh /home /usr/local /etc/containerd /var/lib/containerd"
+DATADIRS="/etc/containerd /etc/ssh /home /tmp /usr/local /var/lib"
 
 # When running from RAM try to move persistent data to data-volume
 # FIXME: the test for tmpfs mounts is probably Alpine-specific


### PR DESCRIPTION
Instead of adding e.g. `/var/lib/buildkit` in a provisioning script, it makes more sense to move all of `/var/lib` to `/mnt/data/var/lib`.

Similarly buildkit seems to create big subdirectories under `/tmp` that look like chroots, so lets move that to the data volume as well to prevent buildkit from running out of space.
