### PR TITLE
Add validation to network.vde[*].name fields

### DIFF
--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -72,7 +72,8 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		args.Mounts = append(args.Mounts, expanded)
 	}
 
-	args.Networks = append(args.Networks, Network{MACAddress: qemuconst.SlirpMACAddress, Name: qemuconst.SlirpNICName})
+	slirpMACAddress := limayaml.MACAddress(instDir)
+	args.Networks = append(args.Networks, Network{MACAddress: slirpMACAddress, Name: qemuconst.SlirpNICName})
 	for _, vde := range y.Network.VDE {
 		args.Networks = append(args.Networks, Network{MACAddress: vde.MACAddress, Name: vde.Name})
 	}

--- a/pkg/cidata/cidata.go
+++ b/pkg/cidata/cidata.go
@@ -15,7 +15,7 @@ import (
 	"github.com/AkihiroSuda/lima/pkg/iso9660util"
 	"github.com/AkihiroSuda/lima/pkg/limayaml"
 	"github.com/AkihiroSuda/lima/pkg/localpathutil"
-	"github.com/AkihiroSuda/lima/pkg/qemu"
+	"github.com/AkihiroSuda/lima/pkg/qemu/qemuconst"
 	"github.com/AkihiroSuda/lima/pkg/sshutil"
 	"github.com/AkihiroSuda/lima/pkg/store/filenames"
 	"github.com/opencontainers/go-digest"
@@ -72,7 +72,7 @@ func GenerateISO9660(instDir, name string, y *limayaml.LimaYAML) error {
 		args.Mounts = append(args.Mounts, expanded)
 	}
 
-	args.Networks = append(args.Networks, Network{MACAddress: qemu.SlirpMACAddress, Name: "eth0"})
+	args.Networks = append(args.Networks, Network{MACAddress: qemuconst.SlirpMACAddress, Name: qemuconst.SlirpNICName})
 	for _, vde := range y.Network.VDE {
 		args.Networks = append(args.Networks, Network{MACAddress: vde.MACAddress, Name: vde.Name})
 	}

--- a/pkg/limayaml/defaults.go
+++ b/pkg/limayaml/defaults.go
@@ -10,6 +10,15 @@ import (
 	"github.com/AkihiroSuda/lima/pkg/guestagent/api"
 )
 
+func MACAddress(uniqueID string) string {
+	// TODO: combine the uniqueID with the host machineID to create a globally unique hash
+	sha := sha256.Sum256([]byte(uniqueID))
+	// According to https://gitlab.com/wireshark/wireshark/-/blob/master/manuf
+	// no well-known MAC addresses start with 0x22.
+	hw := append(net.HardwareAddr{0x22}, sha[0:5]...)
+	return hw.String()
+}
+
 func FillDefault(y *LimaYAML, filePath string) {
 	y.Arch = resolveArch(y.Arch)
 	for i := range y.Images {
@@ -62,12 +71,7 @@ func FillDefault(y *LimaYAML, filePath string) {
 		vde := &y.Network.VDE[i]
 		if vde.MACAddress == "" {
 			// every interface in every limayaml file must get its own unique MAC address
-			uniqueID := fmt.Sprintf("%s#%d", filePath, i)
-			sha := sha256.Sum256([]byte(uniqueID))
-			// According to https://gitlab.com/wireshark/wireshark/-/blob/master/manuf
-			// no well-known MAC addresses start with 0x22.
-			hw := append(net.HardwareAddr{0x22}, sha[0:5]...)
-			vde.MACAddress = hw.String()
+			vde.MACAddress = MACAddress(fmt.Sprintf("%s#%d", filePath, i))
 		}
 		if vde.Name == "" {
 			vde.Name = "vde" + strconv.Itoa(i)

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -12,7 +12,6 @@ import (
 	"github.com/AkihiroSuda/lima/pkg/downloader"
 	"github.com/AkihiroSuda/lima/pkg/iso9660util"
 	"github.com/AkihiroSuda/lima/pkg/limayaml"
-	"github.com/AkihiroSuda/lima/pkg/qemu/qemuconst"
 	"github.com/AkihiroSuda/lima/pkg/store/filenames"
 	"github.com/docker/go-units"
 	"github.com/mattn/go-shellwords"
@@ -131,7 +130,6 @@ func appendArgsIfNoConflict(args []string, k, v string) []string {
 	}
 	return append(args, k, v)
 }
-
 func Cmdline(cfg Config) (string, []string, error) {
 	y := cfg.LimaYAML
 	exe, args, err := getExe(y.Arch)
@@ -197,7 +195,7 @@ func Cmdline(cfg Config) (string, []string, error) {
 	// Network
 	// CIDR is intentionally hardcoded to 192.168.5.0/24, as each of QEMU has its own independent slirp network.
 	args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=192.168.5.0/24,hostfwd=tcp:127.0.0.1:%d-:22", y.SSH.LocalPort))
-	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+qemuconst.SlirpMACAddress)
+	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+limayaml.MACAddress(cfg.InstanceDir))
 	for i, vde := range y.Network.VDE {
 		args = append(args, "-netdev", fmt.Sprintf("vde,id=net%d,sock=%s", i+1, vde.URL))
 		args = append(args, "-device", fmt.Sprintf("virtio-net-pci,netdev=net%d,mac=%s", i+1, vde.MACAddress))

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AkihiroSuda/lima/pkg/downloader"
 	"github.com/AkihiroSuda/lima/pkg/iso9660util"
 	"github.com/AkihiroSuda/lima/pkg/limayaml"
+	"github.com/AkihiroSuda/lima/pkg/qemu/qemuconst"
 	"github.com/AkihiroSuda/lima/pkg/store/filenames"
 	"github.com/docker/go-units"
 	"github.com/mattn/go-shellwords"
@@ -131,10 +132,6 @@ func appendArgsIfNoConflict(args []string, k, v string) []string {
 	return append(args, k, v)
 }
 
-const (
-	SlirpMACAddress = "22:11:11:11:11:11"
-)
-
 func Cmdline(cfg Config) (string, []string, error) {
 	y := cfg.LimaYAML
 	exe, args, err := getExe(y.Arch)
@@ -200,10 +197,10 @@ func Cmdline(cfg Config) (string, []string, error) {
 	// Network
 	// CIDR is intentionally hardcoded to 192.168.5.0/24, as each of QEMU has its own independent slirp network.
 	args = append(args, "-netdev", fmt.Sprintf("user,id=net0,net=192.168.5.0/24,hostfwd=tcp:127.0.0.1:%d-:22", y.SSH.LocalPort))
-	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+SlirpMACAddress)
+	args = append(args, "-device", "virtio-net-pci,netdev=net0,mac="+qemuconst.SlirpMACAddress)
 	for i, vde := range y.Network.VDE {
-			args = append(args, "-netdev", fmt.Sprintf("vde,id=net%d,sock=%s", i+1, vde.URL))
-			args = append(args, "-device", fmt.Sprintf("virtio-net-pci,netdev=net%d,mac=%s", i+1, vde.MACAddress))
+		args = append(args, "-netdev", fmt.Sprintf("vde,id=net%d,sock=%s", i+1, vde.URL))
+		args = append(args, "-device", fmt.Sprintf("virtio-net-pci,netdev=net%d,mac=%s", i+1, vde.MACAddress))
 	}
 
 	// virtio-rng-pci accelerates starting up the OS, according to https://wiki.gentoo.org/wiki/QEMU/Options

--- a/pkg/qemu/qemuconst/qemuconst.go
+++ b/pkg/qemu/qemuconst/qemuconst.go
@@ -1,0 +1,6 @@
+package qemuconst
+
+const (
+	SlirpMACAddress  = "22:11:11:11:11:11"
+	SlirpNICName = "eth0"
+)

--- a/pkg/qemu/qemuconst/qemuconst.go
+++ b/pkg/qemu/qemuconst/qemuconst.go
@@ -1,6 +1,5 @@
 package qemuconst
 
 const (
-	SlirpMACAddress  = "22:11:11:11:11:11"
 	SlirpNICName = "eth0"
 )


### PR DESCRIPTION
Not really happy about the `qemuconst` package, but `limayaml` importing `qemu` would create a circular dependency.

Signed-off-by: Jan Dubois <jan.dubois@suse.com>