### PR TITLE
Persist all of /etc on the data volume

### DIFF
--- a/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
+++ b/pkg/cidata/cidata.TEMPLATE.d/boot/05-persistent-data-volume.sh
@@ -7,7 +7,7 @@ set -eux -o pipefail
 test -f /etc/alpine-release || exit 0
 
 # Data directories that should be persisted across reboots
-DATADIRS="/etc/containerd /etc/ssh /home /tmp /usr/local /var/lib"
+DATADIRS="/etc /home /tmp /usr/local /var/lib"
 
 # When running from RAM try to move persistent data to data-volume
 # FIXME: the test for tmpfs mounts is probably Alpine-specific


### PR DESCRIPTION
Similar to #126

Current motivation: Renaming interfaces via `ip link set XXX name YYY` takes about 5 seconds per interface that we shouldn't have to spend again when an instance is stopped and restarted (yes, it's a micro-optimization 😄).

cloud-init will save the proper config in e.g. `/etc/netplan/50-cloud-init.yaml` or `/etc/udev/rules.d/70-persistent-net.rules`, so devices should come up with the correct names automatically.